### PR TITLE
Shared iOS CI logic

### DIFF
--- a/.github/workflows/ios-lint.yml
+++ b/.github/workflows/ios-lint.yml
@@ -1,0 +1,25 @@
+name: iOS Lint
+
+on:
+  workflow_call:
+
+jobs:
+  format-and-lint:
+    name: Assert that code has been linted and formatted
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install binny to run lint tools 
+        run: |
+          curl -L --output binny https://github.com/customerio/binny/releases/download/latest/binny-macos-x86_64
+          chmod +x binny 
+        shell: bash
+        
+      - name: Run swiftformat. Fail if any errors. 
+        run: make format && git diff --exit-code
+        shell: bash
+        
+      - name: Run swiftlint. Fail if any errors. 
+        run: make lint
+        shell: bash

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Setup iOS
-      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@shared-ios-ci
+      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@v1
     
     # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes.
     - name: Get XCode schemes 

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -14,13 +14,15 @@ on:
     secrets:
       CODECOV_UPLOAD_TOKEN:
         description: 'Codecov upload token'
-        required: true
+        required: false
 
 jobs:
   automated-tests:
     runs-on: macos-14
     permissions:
       checks: write # Need write permission to add test result check.
+    env:
+      CODECOV_UPLOAD_TOKEN: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
     steps:
     - uses: actions/checkout@v4
     
@@ -47,6 +49,7 @@ jobs:
       run: |
         brew tap a7ex/homebrew-formulae && brew install xcresultparser
         xcresultparser --output-format cobertura "${{ inputs.xcresult-name }}" > ".build/coverage.xml"
+      if: env.CODECOV_UPLOAD_TOKEN != ''
   
     - name: Upload code coverage report 
       uses: codecov/codecov-action@0f8570b1a125f4937846a11fcfa3bcd548bd8c97 # v4.6.0
@@ -55,7 +58,8 @@ jobs:
       with: 
         files: .build/coverage.xml
         fail_ci_if_error: true # fail if upload fails so we can catch it and fix it right away.
-        verbose: true 
+        verbose: true
+      if: env.CODECOV_UPLOAD_TOKEN != '' 
 
     - name: Upload test report 
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -1,0 +1,76 @@
+name: iOS Tests
+
+on:
+  workflow_call:
+    inputs:
+      scheme:
+        description: 'Xcode scheme name to test'
+        required: true
+        type: string
+      xcresult-name:
+        description: 'Name of the xcresult bundle (e.g., "MyApp.xcresult")'
+        required: true
+        type: string
+    secrets:
+      CODECOV_UPLOAD_TOKEN:
+        description: 'Codecov upload token'
+        required: true
+
+jobs:
+  automated-tests:
+    runs-on: macos-14
+    permissions:
+      checks: write # Need write permission to add test result check.
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup iOS
+      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
+    
+    # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes.
+    - name: Get XCode schemes 
+      run: xcrun xcodebuild -list
+
+    - name: Setup Ruby to run Fastlane 
+      uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
+      with:
+        ruby-version: '3.2'
+        bundler-cache: true # install dependencies in Gemfile, including Fastlane.
+
+    - name: Run tests 
+      uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
+      with:
+        lane: 'scan'
+
+    # https://about.codecov.io/blog/pre-converting-xcresult-files-for-codecov-using-xcresultparser/
+    - name: Generate code coverage report from .xcresult/ that can be converted to codecov format
+      run: |
+        brew tap a7ex/homebrew-formulae && brew install xcresultparser
+        xcresultparser --output-format cobertura "${{ inputs.xcresult-name }}" > ".build/coverage.xml"
+  
+    - name: Upload code coverage report 
+      uses: codecov/codecov-action@0f8570b1a125f4937846a11fcfa3bcd548bd8c97 # v4.6.0
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_UPLOAD_TOKEN }} 
+      with: 
+        files: .build/coverage.xml
+        fail_ci_if_error: true # fail if upload fails so we can catch it and fix it right away.
+        verbose: true 
+
+    - name: Upload test report 
+      uses: actions/upload-artifact@v4
+      with:
+        name: xcode-test-report
+        path: test-report.*
+      if: ${{ always() }}
+      
+    - name: Publish test results
+      uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe  # v4.3.1
+      with:
+        check_name: XCode macOS tests - Results
+        report_paths: test-report.xml
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        fail_on_failure: true
+        require_tests: true
+      if: ${{ always() }} # if running tests fails, we still want to parse the test results
+

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Setup iOS
-      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
+      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@shared-ios-ci
     
     # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes.
     - name: Get XCode schemes 

--- a/github-actions/ios/setup-ios/v1/action.yml
+++ b/github-actions/ios/setup-ios/v1/action.yml
@@ -1,0 +1,18 @@
+name: Setup iOS
+description: Setup CI with iOS development tools to compile and test iOS source code.
+
+inputs:
+  xcode-version:
+    description: 'Xcode version to install'
+    required: false
+    default: '16.2'
+
+runs:
+  using: "composite"
+  steps:
+  - name: Install XCode 
+    uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+    with:
+      xcode-version: ${{ inputs.xcode-version }}
+
+


### PR DESCRIPTION
Closes: [iOS Native SDK split (FCM)](https://linear.app/customerio/project/ios-native-sdk-split-fcm-e02fbfa5de3f)

This PR extracts some common CI work to be shared for our two iOS repos customerio-ios and customerio-ios-fcm

- iOS env setup
- Running unit tests
- Linting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds reusable iOS lint and test workflows plus a composite action to install Xcode, with optional coverage upload and test reporting.
> 
> - **CI**:
>   - **Reusable Workflows**:
>     - `/.github/workflows/ios-lint.yml`: run `swiftformat` (enforce no diffs) and `swiftlint` on `macos-14`.
>     - `/.github/workflows/ios-test.yml`: parameterized tests (`scheme`, `xcresult-name`), runs Fastlane `scan`, uploads JUnit report/artifacts, and conditionally generates/uploads coverage to Codecov.
>   - **Composite Action**:
>     - `github-actions/ios/setup-ios/v1`: installs Xcode (default `16.2`) for iOS builds/tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 115078dce2725a91dc57ffd9a6bd0d3a46c54103. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->