### PR TITLE
Fix ios test workflow

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Setup iOS
-      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@v1
+      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
     
     # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes.
     - name: Get XCode schemes 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `.github/workflows/ios-test.yml` to use `customerio/mobile-ci-tools/.../setup-ios/v1@main` instead of `@v1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0ddc4c056b1b68be0f3ec1e2dd6d0f5b5039d91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->