### PR TITLE
chore: Updated iOS Testing environment to use MacOS 15 (from 14)

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   automated-tests:
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       checks: write # Need write permission to add test result check.
     env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the GitHub Actions iOS Tests workflow to run on the macOS 15 runner.
> 
> - Changes `jobs.automated-tests.runs-on` from `macos-14` to `macos-15` in `.github/workflows/ios-test.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98456fa2ced9d159a6deda5972d8b8140cd932d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->