### PR TITLE
Chore: Update Xcode build version to use 16.4 by default

### DIFF
--- a/github-actions/ios/setup-ios/v1/action.yml
+++ b/github-actions/ios/setup-ios/v1/action.yml
@@ -5,7 +5,11 @@ inputs:
   xcode-version:
     description: 'Xcode version to install'
     required: false
-    default: '16.2'
+    default: '16.4'
+  iOS-sdk-version:
+    description: 'iOS SDK version to install'
+    required: false
+    default: '18.5'
 
 runs:
   using: "composite"
@@ -14,5 +18,6 @@ runs:
     uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
     with:
       xcode-version: ${{ inputs.xcode-version }}
-
+  - name: Ensure iOS Platform is installed
+    run: xcodebuild -downloadPlatform iOS -buildVersion ${{ inputs.iOS-sdk-version }}
 


### PR DESCRIPTION
Updated the Xcode build version to 16.4.
Added an additional step to ensure that the platform tools of the target iOS version are installed. The version is now available as an input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the iOS CI setup action to align toolchain versions and ensure required platform bits are present.
> 
> - Bumps default `xcode-version` to `16.4` in `github-actions/ios/setup-ios/v1/action.yml`
> - Adds optional `iOS-sdk-version` input (default `18.5`)
> - Adds step to run `xcodebuild -downloadPlatform iOS -buildVersion ${{ inputs.iOS-sdk-version }}` to ensure the iOS platform/SDK is installed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2415ecb8e0115dd09bb76d24731e90bd1e515e01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->