### PR TITLE
Added missing shell parameter.

### DIFF
--- a/github-actions/ios/setup-ios/v1/action.yml
+++ b/github-actions/ios/setup-ios/v1/action.yml
@@ -20,4 +20,5 @@ runs:
       xcode-version: ${{ inputs.xcode-version }}
   - name: Ensure iOS Platform is installed
     run: xcodebuild -downloadPlatform iOS -buildVersion ${{ inputs.iOS-sdk-version }}
+    shell: bash
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the composite GitHub Action runs the iOS platform install command with the correct shell.
> 
> - Adds explicit `shell: bash` to the `xcodebuild` run step in `github-actions/ios/setup-ios/v1/action.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 611bc5165e3beb1029361a53d621b32f8c238311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->