### PR TITLE
Added command to pre-warm simulator

### DIFF
--- a/.github/workflows/ios-lint.yml
+++ b/.github/workflows/ios-lint.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   format-and-lint:
     name: Assert that code has been linted and formatted
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       

--- a/github-actions/ios/setup-ios/v1/action.yml
+++ b/github-actions/ios/setup-ios/v1/action.yml
@@ -19,6 +19,10 @@ runs:
     with:
       xcode-version: ${{ inputs.xcode-version }}
   - name: Ensure iOS Platform is installed
-    run: xcodebuild -downloadPlatform iOS -buildVersion ${{ inputs.iOS-sdk-version }}
+    run: |
+      # 1. Warm up the service
+      xcrun simctl list > /dev/null
+      # 2. Install the required iOS SDK
+      xcodebuild -downloadPlatform iOS -buildVersion ${{ inputs.iOS-sdk-version }}
     shell: bash
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates iOS CI to improve reliability and platform compatibility.
> 
> - Switches `ios-lint.yml` runner from `macos-14` to `macos-15`
> - In `github-actions/ios/setup-ios/v1/action.yml`, adds a pre-warm step (`xcrun simctl list`) before `xcodebuild -downloadPlatform` to ensure the iOS SDK installs correctly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3b4edc4ad59daf24cb8fed4ea14cadbfdc56605. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->