### PR TITLE
Revert to MacOS 14 (for now)

### DIFF
--- a/.github/workflows/ios-lint.yml
+++ b/.github/workflows/ios-lint.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   format-and-lint:
     name: Assert that code has been linted and formatted
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   automated-tests:
-    runs-on: macos-15
+    runs-on: macos-14
     permissions:
       checks: write # Need write permission to add test result check.
     env:

--- a/github-actions/ios/setup-ios/v1/action.yml
+++ b/github-actions/ios/setup-ios/v1/action.yml
@@ -20,5 +20,4 @@ runs:
       xcode-version: ${{ inputs.xcode-version }}
   - name: Ensure iOS Platform is installed
     run: xcodebuild -downloadPlatform iOS -buildVersion ${{ inputs.iOS-sdk-version }}
-    shell: bash
 

--- a/github-actions/ios/setup-ios/v1/action.yml
+++ b/github-actions/ios/setup-ios/v1/action.yml
@@ -19,10 +19,6 @@ runs:
     with:
       xcode-version: ${{ inputs.xcode-version }}
   - name: Ensure iOS Platform is installed
-    run: |
-      # 1. Warm up the service
-      xcrun simctl list > /dev/null
-      # 2. Install the required iOS SDK
-      xcodebuild -downloadPlatform iOS -buildVersion ${{ inputs.iOS-sdk-version }}
+    run: xcodebuild -downloadPlatform iOS -buildVersion ${{ inputs.iOS-sdk-version }}
     shell: bash
 

--- a/github-actions/ios/setup-ios/v1/action.yml
+++ b/github-actions/ios/setup-ios/v1/action.yml
@@ -5,11 +5,7 @@ inputs:
   xcode-version:
     description: 'Xcode version to install'
     required: false
-    default: '16.4'
-  iOS-sdk-version:
-    description: 'iOS SDK version to install'
-    required: false
-    default: '18.5'
+    default: '16.2'
 
 runs:
   using: "composite"
@@ -18,6 +14,5 @@ runs:
     uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
     with:
       xcode-version: ${{ inputs.xcode-version }}
-  - name: Ensure iOS Platform is installed
-    run: xcodebuild -downloadPlatform iOS -buildVersion ${{ inputs.iOS-sdk-version }}
+
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reverts iOS CI to older runner/Xcode and simplifies setup.
> 
> - Switches `ios-lint.yml` and `ios-test.yml` runners to `macos-14`
> - Updates `github-actions/ios/setup-ios/v1/action.yml`: default `xcode-version` to `16.2`; removes `iOS-sdk-version` input and the explicit iOS platform download step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6729f11c7a850fabbd6fa6b9f30de1844fc948bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->