### PR TITLE
ci(ios-test): bump runner to macos-15 and Xcode to 26.2

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -18,17 +18,25 @@ on:
 
 jobs:
   automated-tests:
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       checks: write # Need write permission to add test result check.
     env:
       CODECOV_UPLOAD_TOKEN: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
     steps:
     - uses: actions/checkout@v4
-    
+
+    # Xcode 26.2 (Swift 6.2) is required so SPM can parse modern dependency
+    # manifests that use Swift 6.1+ syntax (e.g. trailing commas in function-
+    # call argument lists, introduced by firebase-ios-sdk 12.13.0). The
+    # setup-ios v1 action's @main ref defaults to 16.2; overriding here keeps
+    # the toolchain bump scoped to this Tests workflow and doesn't change
+    # behavior for the deploy/release/build paths that share the same action.
     - name: Setup iOS
       uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
-    
+      with:
+        xcode-version: '26.2'
+
     # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes.
     - name: Get XCode schemes 
       run: xcrun xcodebuild -list


### PR DESCRIPTION
## Overview

The `ios-test.yml` reusable workflow currently runs on **macos-14 / Xcode 16.2 (Swift 6.0.2)**, which is unable to parse Swift Package manifests that use Swift 6.1+ syntax. This blocks `customerio-ios-fcm`'s Tests because its dependency graph pulls in `firebase-ios-sdk` 12.13.0 (published 2026-05-05), whose `Package.swift` includes a trailing comma in a function-call argument list (Swift 6.1 syntax).

Concretely:

```
/Package.swift:199:5: error: unexpected ',' separator
 197 |         isFoundationModelsSupportedPlatformSwiftSetting(),
 198 |       ],
 199 |     ),
 200 |     .testTarget(
```

SPM fails to resolve dependencies, `xcodebuild` exits 74, and Tests has been red on every customerio-ios-fcm PR since 2026-05-05.

## This PR

Two scoped changes inside `ios-test.yml`:

1. `runs-on: macos-14` → `runs-on: macos-15`
2. Pass `xcode-version: '26.2'` explicitly to the `setup-ios/v1@main` action (so the toolchain bump doesn't depend on changing the action's default, which other workflows rely on)

Xcode 26.2 ships Swift 6.2, which parses Swift 6.1 syntax cleanly. No other behavior changes — Ruby setup, fastlane invocation, codecov upload, JUnit publishing all stay the same.

## Blast radius

Two consumers use `ios-test.yml@main`:

| Repo | Workflow | Effect |
|---|---|---|
| customerio-ios | `.github/workflows/test.yml` | Will run on macos-15 / Xcode 26.2 on next PR. Risk: untested toolchain combination for this Tests path |
| customerio-ios-fcm | `.github/workflows/test.yml` | Unblocks Tests (currently red due to firebase-ios-sdk 12.13.0 manifest parse) |

The `setup-ios` action's default `xcode-version` stays at `16.2`, so workflows that use the action directly (deploy/release/sample-app build paths in customerio-ios, customerio-flutter, customerio-reactnative, customerio-expo-plugin) are not affected.

## Prior history

PRs #4 (macos-15 bump) and #5 (Xcode 16.4 default + iOS-sdk-version input + xcodebuild -downloadPlatform iOS step) landed on 2025-12-29 and were rolled back wholesale by PR #8 on 2025-12-31, including two intermediate fix-up attempts (#6 shell-parameter fix, #7 simulator pre-warm). The revert commit message just says \"for now\" without naming a root cause.

This PR differs in two ways that should reduce the regression risk:

- **Xcode 26.2 vs 16.4.** Xcode 26.x is already in production use in the customer.io org via `setup-ios/v1@MacOS-15+iOS-26`, which `customerio-ios/.github/workflows/deploy-sdk.yml` has been running against successfully. The 16.4 path that got reverted in December isn't being re-attempted.
- **No changes to `setup-ios/v1/action.yml`.** PRs #4+#5 reverted three coordinated changes; this PR only touches `ios-test.yml`. The iOS-sdk-version input and the iOS-platform download step are not reintroduced — macos-15 GitHub-hosted runner images now bundle Xcode 26.x and the iOS 26 simulator runtime by default, so the download step shouldn't be needed.

If Tests breaks for customerio-ios under the new toolchain, easy escape valves available:

- Revert this PR (restores macos-14 + Xcode 16.2 default).
- Add xcode-version and runs-on as workflow_call inputs so consumers can override per repo. Happy to follow up if that's preferred.

## Test plan

- [ ] Confirm customerio-ios-fcm's Tests goes green on its open PR after this merges (currently the only known consumer that's red on the old toolchain).
- [ ] Confirm customerio-ios's Tests stays green on its next PR run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes by moving the iOS test workflow to a newer macOS runner and Xcode toolchain, which can surface new build/test failures due to environment differences.
> 
> **Overview**
> Updates the reusable `ios-test.yml` workflow to run on **`macos-15`** instead of `macos-14`.
> 
> Pins the tests toolchain by passing `xcode-version: '26.2'` to `setup-ios`, ensuring SPM can parse newer SwiftPM manifests while keeping other workflow steps unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29184ca8ff50f09e9aa94e99fe3c20d28851e9d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->