### PR TITLE
feat(android-publish): automated, gated release workflow + versioning docs

### DIFF
--- a/.github/workflows/android-publish-release.yml
+++ b/.github/workflows/android-publish-release.yml
@@ -1,0 +1,69 @@
+name: Release android-publish plugin
+
+# Automated release of the io.customer.android:android-publish Gradle plugin to Maven Central.
+#
+# Trigger + guards (see gradle-plugins/android-publish/RELEASING.md):
+#   1. paths filter  — only runs when the plugin itself changes (never for CI/action-only commits).
+#   2. tag idempotency — only publishes when gradle.properties `pluginVersion` is a version that
+#      hasn't been released yet (i.e. no android-publish-v<version> tag). A plugin-dir change that
+#      doesn't bump the version (a comment, a test) is a no-op.
+# Net: the only human action is bumping `pluginVersion` in the PR; everything else is automatic.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'gradle-plugins/android-publish/**'
+
+permissions:
+  contents: write # create + push the release tag
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: gradle-plugins/android-publish
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need full history/tags for the idempotency check
+
+      - name: Read plugin version
+        id: ver
+        run: echo "version=$(grep '^pluginVersion=' gradle.properties | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to release
+        id: gate
+        working-directory: .
+        run: |
+          tag="android-publish-v${{ steps.ver.outputs.version }}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists — nothing to release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Releasing $tag"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Android
+        if: steps.gate.outputs.release == 'true'
+        uses: ./github-actions/android/setup-android/v1
+
+      - name: Publish to Maven Central
+        if: steps.gate.outputs.release == 'true'
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+
+      - name: Tag the release
+        if: steps.gate.outputs.release == 'true'
+        working-directory: .
+        run: |
+          tag="android-publish-v${{ steps.ver.outputs.version }}"
+          git tag "$tag"
+          git push origin "$tag"

--- a/gradle-plugins/android-publish/README.md
+++ b/gradle-plugins/android-publish/README.md
@@ -56,6 +56,12 @@ For local development before the plugin is published, consume it as an included 
 includeBuild("../mobile-ci-tools/gradle-plugins/android-publish")
 ```
 
+## Releasing
+
+The plugin is published to Maven Central by bumping `pluginVersion` in `gradle.properties`; merging
+to `main` then auto-publishes and tags. See **[RELEASING.md](./RELEASING.md)** for the full process,
+the over-release guards, and why we don't use semantic-release here.
+
 ## Environment variables (publishing)
 
 `MODULE_VERSION`, `OSSRH_USERNAME`, `OSSRH_PASSWORD`, `SONATYPE_STAGING_PROFILE_ID`,

--- a/gradle-plugins/android-publish/RELEASING.md
+++ b/gradle-plugins/android-publish/RELEASING.md
@@ -1,0 +1,69 @@
+# Releasing & versioning — `io.customer.android:android-publish`
+
+This plugin is published to Maven Central. Releases are **automated but gated on an explicit,
+reviewable version bump**, so they can't fire by accident.
+
+## Versioning
+
+- The version lives in **one place**: `pluginVersion` in [`gradle.properties`](./gradle.properties).
+- Standard [semver](https://semver.org/). Because consumers **pin** the plugin version, a change
+  here never affects a repo until it bumps on its own schedule.
+- This logic changes rarely (historically ~once a year), so releases are infrequent and the
+  version moves slowly.
+
+## How a release is triggered
+
+The release is driven by the [`Release android-publish plugin`](../../.github/workflows/android-publish-release.yml)
+workflow. The **only manual step is bumping `pluginVersion`**:
+
+1. In the PR that changes the plugin, bump `pluginVersion` (e.g. `0.1.0` → `0.2.0`).
+2. Merge to `main`.
+3. The workflow takes over automatically:
+   - builds the plugin,
+   - publishes to the Sonatype Central Portal and **closes + releases** the staging repo
+     (`publishToSonatype closeAndReleaseSonatypeStagingRepository`),
+   - tags the commit `android-publish-v<version>`.
+
+No version is typed at release time, no tag is cut by hand, no dispatch to remember.
+
+## Why it can't over-release
+
+Two independent guards, both automatic:
+
+| Guard | Prevents |
+| --- | --- |
+| **`paths:` filter** on `gradle-plugins/android-publish/**` | Releases from unrelated commits — iOS/Android actions, Slack, root README, other CI. Those never trigger the workflow. |
+| **Tag idempotency** (`android-publish-v<version>` must not already exist) | Releases from plugin-dir changes that *don't* bump the version — a comment, a test, a doc tweak. The workflow runs but no-ops. |
+
+So a release happens **only** when `pluginVersion` changes to a value that hasn't been tagged yet.
+This is deliberately not semantic-release: in a shared, mixed-purpose repo, commit-message-driven
+versioning would sweep in unrelated commits and mis-attribute or over-fire releases.
+
+## Consuming a released version
+
+```kotlin
+// settings.gradle.kts
+pluginManagement { repositories { mavenCentral() } }
+
+// build.gradle(.kts)
+plugins { id("io.customer.android.publish-root") version "<version>" }   // root
+plugins { id("io.customer.android.publish-module") version "<version>" } // module
+```
+
+## Local development (no release)
+
+Consume the plugin from a sibling `mobile-ci-tools` checkout instead of Maven Central:
+
+```kotlin
+// consumer settings.gradle(.kts)
+includeBuild("../mobile-ci-tools/gradle-plugins/android-publish")
+```
+
+In the SDK repos this is gated behind `-PuseLocalPublishPlugin=true`. You can also install to your
+local Maven cache: `./gradlew publishToMavenLocal`.
+
+## Prerequisites (one-time, repo settings)
+
+These secrets must exist in `mobile-ci-tools` for the release workflow to publish:
+`OSSRH_USERNAME`, `OSSRH_PASSWORD`, `SONATYPE_STAGING_PROFILE_ID`, `SIGNING_KEY_ID`,
+`SIGNING_KEY`, `SIGNING_PASSWORD`.

--- a/gradle-plugins/android-publish/build.gradle.kts
+++ b/gradle-plugins/android-publish/build.gradle.kts
@@ -2,11 +2,15 @@ plugins {
     `kotlin-dsl`
     `maven-publish`
     signing
+    // Used to publish THIS plugin to the Sonatype Central Portal (close + release), the same way
+    // the convention applies it to consumer projects.
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
 group = "io.customer.android"
-// Plugin version — bump only when the publishing logic itself changes (historically ~once/year).
-version = System.getenv("MODULE_VERSION") ?: "0.1.0"
+// Single source of truth for the plugin version. Bumping this line in a PR is what triggers a
+// release (see RELEASING.md) — bump only when the publishing logic changes (historically ~once/year).
+version = providers.gradleProperty("pluginVersion").get()
 
 repositories {
     gradlePluginPortal()
@@ -25,17 +29,46 @@ dependencies {
 //   io.customer.android.publish-root.gradle.kts    -> id "io.customer.android.publish-root"
 //   io.customer.android.publish-module.gradle.kts  -> id "io.customer.android.publish-module"
 
-// Bootstrap: this plugin publishes itself with plain maven-publish (it cannot apply itself the
-// first time). CI injects the same Sonatype/signing env vars used by the module convention.
+// Maven Central requires complete POM metadata on every published artifact, including the
+// auto-generated plugin-marker publications.
 publishing {
-    repositories {
-        maven {
-            name = "sonatypeStaging"
-            url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_PASSWORD")
+    publications.withType<MavenPublication>().configureEach {
+        pom {
+            name.set("Customer.io Android Publishing Plugin")
+            description.set("Shared in-house Gradle convention for publishing Customer.io Android artifacts to Maven Central.")
+            url.set("https://github.com/customerio/mobile-ci-tools")
+            licenses {
+                license {
+                    name.set("MIT")
+                    url.set("https://github.com/customerio/mobile-ci-tools/blob/main/LICENSE")
+                }
             }
+            developers {
+                developer {
+                    id.set("customerio")
+                    name.set("Customer.io Team")
+                    email.set("win@customer.io")
+                }
+            }
+            scm {
+                url.set("https://github.com/customerio/mobile-ci-tools")
+                connection.set("scm:git@github.com:customerio/mobile-ci-tools.git")
+                developerConnection.set("scm:git@github.com:customerio/mobile-ci-tools.git")
+            }
+        }
+    }
+}
+
+// Sonatype Central Portal staging. `publishToSonatype closeAndReleaseSonatypeStagingRepository`
+// uploads and promotes to Maven Central in one shot.
+nexusPublishing {
+    repositories {
+        sonatype {
+            username.set(System.getenv("OSSRH_USERNAME") ?: "")
+            password.set(System.getenv("OSSRH_PASSWORD") ?: "")
+            stagingProfileId.set(System.getenv("SONATYPE_STAGING_PROFILE_ID") ?: "")
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }

--- a/gradle-plugins/android-publish/gradle.properties
+++ b/gradle-plugins/android-publish/gradle.properties
@@ -1,0 +1,3 @@
+# Single source of truth for the published plugin version.
+# Bumping this line (in a PR that changes the plugin) is what triggers a release — see RELEASING.md.
+pluginVersion=0.1.0


### PR DESCRIPTION
**Stacked on #10** (base: `android-publish-plugin`). Adds how the plugin gets released — automated, but structurally unable to over-release.

## How a release works
The **only manual step is bumping `pluginVersion`** in `gradle-plugins/android-publish/gradle.properties`. On merge to `main`, the new `Release android-publish plugin` workflow publishes to Maven Central (`publishToSonatype closeAndReleaseSonatypeStagingRepository`) and tags `android-publish-v<version>`. No version typed at release time, no hand-cut tags, no dispatch.

## Why it can't over-release (your concern with semantic-release)
Two independent, automatic guards:
- **`paths:` filter** (`gradle-plugins/android-publish/**`) — CI/action-only/root changes never trigger it.
- **Tag idempotency** — runs but no-ops unless `pluginVersion` is a new value with no existing `android-publish-v<version>` tag. So a comment/test tweak in the plugin dir doesn't release.

Deliberately **not** semantic-release: in a shared mixed-purpose repo, commit-message-driven versioning sweeps in unrelated commits and mis-attributes/over-fires.

## Changes
- `gradle.properties`: `pluginVersion` = single source of truth; `build.gradle.kts` reads it.
- `build.gradle.kts`: apply `gradle-nexus` to the producer itself → gets `closeAndReleaseSonatypeStagingRepository` (promote to Central, not just upload to staging); add POM metadata required on the plugin + marker artifacts.
- `.github/workflows/android-publish-release.yml`: the gated release workflow.
- `RELEASING.md`: versioning + release process + guards + consumption + local dev.

## Validated locally
Build green; version resolves from `gradle.properties`; `closeAndReleaseSonatypeStagingRepository` present; `publishToMavenLocal` emits the plugin + marker with complete POMs.

> Prereq: `OSSRH_*` / `SIGNING_*` / `SONATYPE_STAGING_PROFILE_ID` secrets must be added to `mobile-ci-tools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)