### PR TITLE
release: io.customer.android.publish 0.1.0

### DIFF
--- a/gradle-plugins/android-publish/build.gradle.kts
+++ b/gradle-plugins/android-publish/build.gradle.kts
@@ -18,6 +18,12 @@ repositories {
     mavenCentral()
 }
 
+// Maven Central requires a -sources.jar and -javadoc.jar for the published plugin artifact.
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 dependencies {
     // The convention scripts apply these plugins, so their markers must be on the classpath.
     // Both are pinned, in-house-reviewed versions — see README for the supply-chain rationale.

--- a/gradle-plugins/android-publish/gradle.properties
+++ b/gradle-plugins/android-publish/gradle.properties
@@ -1,3 +1,3 @@
 # Single source of truth for the published plugin version.
 # Bumping this line (in a PR that changes the plugin) is what triggers a release — see RELEASING.md.
-pluginVersion=0.1.0-SNAPSHOT
+pluginVersion=0.1.0


### PR DESCRIPTION
Publishes the first real version of the shared Android publishing plugin.

**Merging this to `main` triggers a real Maven Central release** — the release workflow publishes `io.customer.android:android-publish:0.1.0` and tags `android-publish-v0.1.0`.

## Changes
- **Add `-sources.jar` / `-javadoc.jar`** to the plugin's own publication. Maven Central requires both; a `close` rehearsal (mode=close on an alpha) initially failed validation without them, then **passed** once added.
- Bump `pluginVersion` `0.1.0-SNAPSHOT → 0.1.0`.

## Pre-merge verification done
- `dry-run` dispatch — task graph ✓
- `snapshot` dispatch — real authenticated upload to the snapshot repo ✓ (new Central Portal token)
- `close` dispatch on alpha — staging upload + signing + **Central validation passed** ✓

## After merge
- Verify `io.customer.android:android-publish:0.1.0` on Central.
- Bump `main` back to `0.2.0-SNAPSHOT` (hygiene, keeps future merges inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to Gradle publishing configuration and version bump; no application runtime behavior changes, though merge triggers a real Maven Central release.
> 
> **Overview**
> Prepares the **first non-SNAPSHOT release** of `io.customer.android:android-publish` by setting `pluginVersion` to **0.1.0** (from `0.1.0-SNAPSHOT`).
> 
> Adds a **`java` publication block** with `withSourcesJar()` and `withJavadocJar()` so the plugin artifact ships the **`-sources.jar` and `-javadoc.jar`** Maven Central requires—without these, staging validation was failing during release rehearsal.
> 
> Merging to `main` is intended to trigger the real Central publish and tag `android-publish-v0.1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cf1c59589683382dd1b4ace56a2c83703c99f9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->