### PR TITLE
ci: move shared iOS workflows to macos-26 and make the runner selectable

### DIFF
--- a/.github/workflows/ios-lint.yml
+++ b/.github/workflows/ios-lint.yml
@@ -2,24 +2,44 @@ name: iOS Lint
 
 on:
   workflow_call:
+    inputs:
+      runner-label:
+        description: 'Runner label to run on (e.g. macos-26, xcode-27).'
+        required: false
+        type: string
+        default: 'macos-26'
+  # Mirrored so the runner can be exercised from the Actions tab without a consumer PR.
+  # Note the lint steps themselves need a Swift repo checked out, so a dispatch run in
+  # mobile-ci-tools reports the runner and then fails at `make format` — that is expected.
+  workflow_dispatch:
+    inputs:
+      runner-label:
+        description: 'Runner label to run on (e.g. macos-26, xcode-27).'
+        required: false
+        type: string
+        default: 'macos-26'
 
 jobs:
   format-and-lint:
     name: Assert that code has been linted and formatted
-    runs-on: macos-14
+    runs-on: ${{ inputs.runner-label }}
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Install binny to run lint tools 
+
+      - name: Install binny to run lint tools
+        # Uses the arm64 asset rather than binny-macos-x86_64. Every macOS runner image is
+        # arm64; the x86_64 binary only worked because Rosetta 2 happened to be present on
+        # macos-14. Rosetta availability on macos-26 is not documented in the image readme,
+        # so depend on the native binary instead of on an undocumented shim.
         run: |
-          curl -L --output binny https://github.com/customerio/binny/releases/download/latest/binny-macos-x86_64
-          chmod +x binny 
+          curl -L --output binny https://github.com/customerio/binny/releases/download/latest/binny-macos-m1
+          chmod +x binny
         shell: bash
-        
-      - name: Run swiftformat. Fail if any errors. 
+
+      - name: Run swiftformat. Fail if any errors.
         run: make format && git diff --exit-code
         shell: bash
-        
-      - name: Run swiftlint. Fail if any errors. 
+
+      - name: Run swiftlint. Fail if any errors.
         run: make lint
         shell: bash

--- a/.github/workflows/ios-lint.yml
+++ b/.github/workflows/ios-lint.yml
@@ -8,16 +8,6 @@ on:
         required: false
         type: string
         default: 'macos-26'
-  # Mirrored so the runner can be exercised from the Actions tab without a consumer PR.
-  # Note the lint steps themselves need a Swift repo checked out, so a dispatch run in
-  # mobile-ci-tools reports the runner and then fails at `make format` — that is expected.
-  workflow_dispatch:
-    inputs:
-      runner-label:
-        description: 'Runner label to run on (e.g. macos-26, xcode-27).'
-        required: false
-        type: string
-        default: 'macos-26'
 
 jobs:
   format-and-lint:
@@ -27,12 +17,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install binny to run lint tools
-        # Uses the arm64 asset rather than binny-macos-x86_64. Every macOS runner image is
-        # arm64; the x86_64 binary only worked because Rosetta 2 happened to be present on
-        # macos-14. Rosetta availability on macos-26 is not documented in the image readme,
-        # so depend on the native binary instead of on an undocumented shim.
+        # arm64 asset, not x86_64: every macOS image is arm64, and the x86_64 binary only ran
+        # because Rosetta happened to be installed on macos-14. -f so a 404 fails here rather
+        # than writing an error page to ./binny and failing later inside `make format`.
         run: |
-          curl -L --output binny https://github.com/customerio/binny/releases/download/latest/binny-macos-m1
+          curl -fL --output binny https://github.com/customerio/binny/releases/download/latest/binny-macos-m1
           chmod +x binny
         shell: bash
 

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -25,29 +25,6 @@ on:
       CODECOV_UPLOAD_TOKEN:
         description: 'Codecov upload token'
         required: false
-  # Mirrored so the runner and Xcode selection can be exercised from the Actions tab without a
-  # consumer PR. Note the test steps need an Xcode project checked out, so a dispatch run in
-  # mobile-ci-tools reports the toolchain and then fails at `xcodebuild -list` — that is expected.
-  workflow_dispatch:
-    inputs:
-      runner-label:
-        description: 'Runner label to run on (e.g. macos-26, xcode-27).'
-        required: false
-        type: string
-        default: 'macos-26'
-      xcode-version:
-        description: 'Xcode version to select. Leave empty on preview images (xcode-27) where only one Xcode is installed.'
-        required: false
-        type: string
-        default: '26.6'
-      scheme:
-        description: 'Xcode scheme name to test'
-        required: true
-        type: string
-      xcresult-name:
-        description: 'Name of the xcresult bundle (e.g., "MyApp.xcresult")'
-        required: true
-        type: string
 
 jobs:
   automated-tests:
@@ -59,9 +36,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # An empty xcode-version is passed through deliberately: the action skips selecting an
-    # Xcode in that case, which is required on preview images such as xcode-27 where a single
-    # beta Xcode is installed and setup-xcode cannot resolve the version string.
+    # Xcode 26.x is a floor, not a preference: SPM needs Swift 6.1+ to parse firebase-ios-sdk's
+    # manifest (trailing commas in call argument lists). Do not lower the default below 26.
     - name: Setup iOS
       uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
       with:

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -63,7 +63,7 @@ jobs:
     # Xcode in that case, which is required on preview images such as xcode-27 where a single
     # beta Xcode is installed and setup-xcode cannot resolve the version string.
     - name: Setup iOS
-      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
+      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
       with:
         xcode-version: ${{ inputs.xcode-version }}
 

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -3,6 +3,16 @@ name: iOS Tests
 on:
   workflow_call:
     inputs:
+      runner-label:
+        description: 'Runner label to run on (e.g. macos-26, xcode-27).'
+        required: false
+        type: string
+        default: 'macos-26'
+      xcode-version:
+        description: 'Xcode version to select. Leave empty on preview images (xcode-27) where only one Xcode is installed.'
+        required: false
+        type: string
+        default: '26.6'
       scheme:
         description: 'Xcode scheme name to test'
         required: true
@@ -15,10 +25,33 @@ on:
       CODECOV_UPLOAD_TOKEN:
         description: 'Codecov upload token'
         required: false
+  # Mirrored so the runner and Xcode selection can be exercised from the Actions tab without a
+  # consumer PR. Note the test steps need an Xcode project checked out, so a dispatch run in
+  # mobile-ci-tools reports the toolchain and then fails at `xcodebuild -list` — that is expected.
+  workflow_dispatch:
+    inputs:
+      runner-label:
+        description: 'Runner label to run on (e.g. macos-26, xcode-27).'
+        required: false
+        type: string
+        default: 'macos-26'
+      xcode-version:
+        description: 'Xcode version to select. Leave empty on preview images (xcode-27) where only one Xcode is installed.'
+        required: false
+        type: string
+        default: '26.6'
+      scheme:
+        description: 'Xcode scheme name to test'
+        required: true
+        type: string
+      xcresult-name:
+        description: 'Name of the xcresult bundle (e.g., "MyApp.xcresult")'
+        required: true
+        type: string
 
 jobs:
   automated-tests:
-    runs-on: macos-15
+    runs-on: ${{ inputs.runner-label }}
     permissions:
       checks: write # Need write permission to add test result check.
     env:
@@ -26,16 +59,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Xcode 26.2 (Swift 6.2) is required so SPM can parse modern dependency
-    # manifests that use Swift 6.1+ syntax (e.g. trailing commas in function-
-    # call argument lists, introduced by firebase-ios-sdk 12.13.0). The
-    # setup-ios v1 action's @main ref defaults to 16.2; overriding here keeps
-    # the toolchain bump scoped to this Tests workflow and doesn't change
-    # behavior for the deploy/release/build paths that share the same action.
+    # An empty xcode-version is passed through deliberately: the action skips selecting an
+    # Xcode in that case, which is required on preview images such as xcode-27 where a single
+    # beta Xcode is installed and setup-xcode cannot resolve the version string.
     - name: Setup iOS
-      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
+      uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
       with:
-        xcode-version: '26.2'
+        xcode-version: ${{ inputs.xcode-version }}
 
     # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes.
     - name: Get XCode schemes 

--- a/github-actions/ios/setup-ios/v1/action.yml
+++ b/github-actions/ios/setup-ios/v1/action.yml
@@ -3,19 +3,15 @@ description: Setup CI with iOS development tools to compile and test iOS source 
 
 inputs:
   xcode-version:
-    description: 'Xcode version to select. Leave empty to use the image default (required on preview images such as xcode-27, where setup-xcode cannot resolve a beta string).'
+    description: 'Xcode version to select, e.g. "26.6". Leave empty only to deliberately use the image default — required on preview images such as xcode-27, where a single beta Xcode is installed and setup-xcode cannot resolve the version string.'
     required: false
     default: '26.6'
 
 runs:
   using: "composite"
   steps:
-  # Deliberately no simulator-runtime install step here, unlike the MacOS-15+iOS-26 and
-  # MacOS-26+iOS-26 branches. The macos-26 image already ships the iOS 26.2 / 26.4 / 26.5
-  # simulator runtimes, so that step was a ~200s no-op at best and a fetch of an unused
-  # runtime at worst. A job that genuinely needs a runtime the image lacks should now fail
-  # loudly rather than quietly fetch it. See images/macos/macos-26-arm64-Readme.md in
-  # actions/runner-images for the bundled list.
+  # No `xcodebuild -downloadPlatform iOS` step: the macos-26 image already ships the iOS
+  # simulator runtimes we test against, so it only ever fetched one no job used.
   - name: Install XCode
     if: ${{ inputs.xcode-version != '' }}
     uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0

--- a/github-actions/ios/setup-ios/v1/action.yml
+++ b/github-actions/ios/setup-ios/v1/action.yml
@@ -3,16 +3,21 @@ description: Setup CI with iOS development tools to compile and test iOS source 
 
 inputs:
   xcode-version:
-    description: 'Xcode version to install'
+    description: 'Xcode version to select. Leave empty to use the image default (required on preview images such as xcode-27, where setup-xcode cannot resolve a beta string).'
     required: false
-    default: '16.2'
+    default: '26.6'
 
 runs:
   using: "composite"
   steps:
-  - name: Install XCode 
+  # Deliberately no simulator-runtime install step here, unlike the MacOS-15+iOS-26 and
+  # MacOS-26+iOS-26 branches. The macos-26 image already ships the iOS 26.2 / 26.4 / 26.5
+  # simulator runtimes, so that step was a ~200s no-op at best and a fetch of an unused
+  # runtime at worst. A job that genuinely needs a runtime the image lacks should now fail
+  # loudly rather than quietly fetch it. See images/macos/macos-26-arm64-Readme.md in
+  # actions/runner-images for the bundled list.
+  - name: Install XCode
+    if: ${{ inputs.xcode-version != '' }}
     uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
     with:
       xcode-version: ${{ inputs.xcode-version }}
-
-


### PR DESCRIPTION
[MBL-2224: Migrate iOS CI to `macos-26` + Xcode 26.6, and stop downloading simulator runtimes we already have](https://linear.app/customerio/issue/MBL-2224/migrate-ios-ci-to-macos-26-xcode-266-and-stop-downloading-simulator)

---

Two problems meet here. Our shared lint workflow was the last job anywhere in the fleet on macOS 14, which is fully retired on 2 Nov 2026 and has brownout windows through October during which those jobs simply fail. And the shared iOS setup step installed a simulator runtime our images already ship — around 14 hours of macOS runner wall-clock a week across the fleet, spent fetching a runtime no job ever used.

Moves the shared workflows from macOS 14 and 15 to 26, pins Xcode to the new image's default, drops that runtime install, and exposes the runner and Xcode version as inputs so a consumer branch can opt onto a preview image without changing this repo.

## Sequencing

This is the hinge of the migration: it makes `main` the canonical source for the shared iOS setup.

```
1. Scanfiles         customerio-ios#1194 + customerio-ios-fcm#10
2. THIS PR                                    <- main becomes canonical
3. flip consumers to @main, verify green
4. merge consumers   #383 #627 #378 #1195 + customerio-ios-fcm#12
```

**The two Scanfile PRs must land first.** This changes lint and test for `customerio-ios` and `customerio-ios-fcm` at the same moment, and both repos currently pin a simulator that does not exist on the new image — without those PRs, both silently fall back to a default simulator, which is the exact condition this migration exists to remove.

There is no tag to pin in this repo, so both consumers move together and rollback is another commit to `main`.

## Validated on real runs

Not merely reviewed. Because these workflows are consumed `@main`, no ordinary PR can exercise them, so this branch was run through throwaway consumer PRs (`customerio-ios#1196`, `customerio-ios-fcm#11`):

- **lint green on `macos-26`** in both repos, with the arm64 binny binary
- **tests green on `macos-26`** with Xcode 26.6, destination resolving to `OS:26.2, name:iPhone 17`
- no `Downloading iOS … Simulator`, no `falling back to default simulator`

That covers the two changes with no rollback path other than a forward commit.

## Opting a branch onto Xcode 27

Possible from the consumer repo alone:

```yaml
jobs:
  test:
    uses: customerio/mobile-ci-tools/.github/workflows/ios-test.yml@main
    with:
      runner-label: xcode-27
      xcode-version: ''      # image default; skips setup-xcode
      scheme: Customer.io-Package
      xcresult-name: Customer.io-Package.xcresult
```

The beta build number is deliberately not pinnable: on that image Xcode 27.0 beta is the sole installed version and `setup-xcode` may not resolve a beta string — hence the empty-value skip. It ships iOS 27.0 simulators only, so a branch opting in needs its own Scanfile override.

## One judgement call

The lint job now fetches binny's arm64 asset instead of the x86_64 one. Every macOS image is arm64 — the x86_64 binary only ran because Rosetta happened to be present on `macos-14`, and its availability on `macos-26` is undocumented. Now verified working on `macos-26` via the runs above. Reverting one line is the isolated fix if it ever misbehaves. The `curl` also gained `-f`, so a 404 fails at the download rather than writing an error page to `./binny` and surfacing as an unreadable `make format` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)