### PR TITLE
ci: move the shared ios workflow onto a supported ruby runtime

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -13,6 +13,16 @@ on:
         required: false
         type: string
         default: '26.6'
+      ruby-version:
+        description: 'Ruby version to install for Fastlane. Must match what the calling repo''s Gemfile.lock resolves against.'
+        required: false
+        # Transitional default. A caller's Gemfile.lock is resolved against one Ruby line, and a
+        # lock resolved on 3.4 will not install on 3.2 (fastlane 2.237 admits excon 1.7, which
+        # needs >= 3.3). Keeping 3.2 here means merging this change alone is a no-op; each caller
+        # moves to '3.4' in the same PR that bumps its own lock. Drop this default once both
+        # customerio-ios and customerio-ios-fcm pass the input explicitly.
+        type: string
+        default: '3.2'
       scheme:
         description: 'Xcode scheme name to test'
         required: true
@@ -50,7 +60,7 @@ jobs:
     - name: Setup Ruby to run Fastlane 
       uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
-        ruby-version: '3.4'
+        ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: true # install dependencies in Gemfile, including Fastlane.
 
     - name: Run tests 

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -48,9 +48,9 @@ jobs:
       run: xcrun xcodebuild -list
 
     - name: Setup Ruby to run Fastlane 
-      uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
-        ruby-version: '3.2'
+        ruby-version: '3.4'
         bundler-cache: true # install dependencies in Gemfile, including Fastlane.
 
     - name: Run tests 


### PR DESCRIPTION
Ruby 3.2 → 3.4. Consumed at @main, so this merges only after customerio-ios and customerio-ios-fcm are green.

Contributes to MBL-2245

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with a transitional default that preserves current Ruby 3.2 behavior until calling repos opt into 3.4 explicitly.
> 
> **Overview**
> The reusable **iOS Tests** workflow now accepts a **`ruby-version`** input (default **`3.2`**) so Fastlane runs on the same Ruby line as each caller’s **`Gemfile.lock`**, enabling a coordinated move to **3.4** without breaking repos that still lock on 3.2.
> 
> **`ruby/setup-ruby`** is bumped to **v1.321.0**, and the setup step uses **`${{ inputs.ruby-version }}`** instead of a hardcoded **3.2**. Comments document that merging this alone is a no-op until **`customerio-ios`** and **`customerio-ios-fcm`** pass **`3.4`** in the same PRs that update their locks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ad2e9dc1d2ffd3c4c3fc1fa2e718b45cdd7c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->