### PR TITLE
ci(ios): share Xcode toolchain reporting

### DIFF
--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -27,7 +27,7 @@ jobs:
           done
 
       - name: Run shellcheck
-        run: shellcheck github-actions/ios/report-toolchain/v1/report.sh github-actions/ios/report-toolchain/v1/test.sh
+        run: shellcheck github-actions/ios/report-toolchain/v1/*.sh
 
       - name: Test toolchain reporter
         run: bash github-actions/ios/report-toolchain/v1/test.sh
@@ -39,3 +39,19 @@ jobs:
 
       - name: Test with the macOS system Bash
         run: /bin/bash github-actions/ios/report-toolchain/v1/test.sh
+
+      - name: Smoke-test the composite action on the hosted toolchain
+        id: reporter
+        uses: ./github-actions/ios/report-toolchain/v1
+
+      - name: Verify composite outputs
+        env:
+          CLASSIFICATION: ${{ steps.reporter.outputs.classification }}
+          XCODE_VERSION: ${{ steps.reporter.outputs.xcode-version }}
+          IPHONEOS_SDK: ${{ steps.reporter.outputs.iphoneos-sdk }}
+          IPHONESIMULATOR_SDK: ${{ steps.reporter.outputs.iphonesimulator-sdk }}
+        run: |
+          test "$CLASSIFICATION" = 'reported-toolchain'
+          test -n "$XCODE_VERSION"
+          test -n "$IPHONEOS_SDK"
+          test -n "$IPHONESIMULATOR_SDK"

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -1,0 +1,30 @@
+name: iOS actions
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/ios-actions-test.yml'
+      - 'github-actions/ios/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/ios-actions-test.yml'
+      - 'github-actions/ios/**'
+
+permissions:
+  contents: read
+
+jobs:
+  shell-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check shell syntax
+        run: bash -n github-actions/ios/report-toolchain/v1/report.sh github-actions/ios/report-toolchain/v1/test.sh
+
+      - name: Run shellcheck
+        run: shellcheck github-actions/ios/report-toolchain/v1/report.sh github-actions/ios/report-toolchain/v1/test.sh
+
+      - name: Test toolchain reporter
+        run: bash github-actions/ios/report-toolchain/v1/test.sh

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -21,10 +21,21 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check shell syntax
-        run: bash -n github-actions/ios/report-toolchain/v1/report.sh github-actions/ios/report-toolchain/v1/test.sh
+        run: |
+          for script in github-actions/ios/report-toolchain/v1/*.sh; do
+            bash -n "$script"
+          done
 
       - name: Run shellcheck
         run: shellcheck github-actions/ios/report-toolchain/v1/report.sh github-actions/ios/report-toolchain/v1/test.sh
 
       - name: Test toolchain reporter
         run: bash github-actions/ios/report-toolchain/v1/test.sh
+
+  macos-bash-tests:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Test with the macOS system Bash
+        run: /bin/bash github-actions/ios/report-toolchain/v1/test.sh

--- a/github-actions/ios/report-toolchain/v1/action.yml
+++ b/github-actions/ios/report-toolchain/v1/action.yml
@@ -1,0 +1,43 @@
+name: Report iOS toolchain
+description: Record the hosted Apple toolchain and optionally require Xcode and iOS SDK major versions.
+
+inputs:
+  expected-xcode-major:
+    description: Expected Xcode major version. Leave empty to report without a version assertion.
+    required: false
+    default: ''
+  expected-ios-sdk-major:
+    description: Expected iphoneos and iphonesimulator SDK major version. Leave empty to report without a version assertion.
+    required: false
+    default: ''
+
+outputs:
+  classification:
+    description: reported-toolchain, verified-toolchain, or toolchain-mismatch.
+    value: ${{ steps.report.outputs.classification }}
+  image-version:
+    description: Hosted runner image version.
+    value: ${{ steps.report.outputs.image-version }}
+  xcode-version:
+    description: Selected Xcode version.
+    value: ${{ steps.report.outputs.xcode-version }}
+  xcode-build:
+    description: Selected Xcode build identifier.
+    value: ${{ steps.report.outputs.xcode-build }}
+  iphoneos-sdk:
+    description: Selected iphoneos SDK version.
+    value: ${{ steps.report.outputs.iphoneos-sdk }}
+  iphonesimulator-sdk:
+    description: Selected iphonesimulator SDK version.
+    value: ${{ steps.report.outputs.iphonesimulator-sdk }}
+
+runs:
+  using: composite
+  steps:
+    - name: Report and verify Apple toolchain
+      id: report
+      shell: bash
+      env:
+        EXPECTED_XCODE_MAJOR: ${{ inputs.expected-xcode-major }}
+        EXPECTED_IOS_SDK_MAJOR: ${{ inputs.expected-ios-sdk-major }}
+      run: bash "$GITHUB_ACTION_PATH/report.sh"

--- a/github-actions/ios/report-toolchain/v1/action.yml
+++ b/github-actions/ios/report-toolchain/v1/action.yml
@@ -1,5 +1,5 @@
 name: Report iOS toolchain
-description: Record the hosted Apple toolchain and optionally require Xcode and iOS SDK major versions.
+description: Record the hosted Apple toolchain on macOS and optionally require Xcode and iOS SDK major versions. Inspection failures always fail closed.
 
 inputs:
   expected-xcode-major:

--- a/github-actions/ios/report-toolchain/v1/report.sh
+++ b/github-actions/ios/report-toolchain/v1/report.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+expected_xcode_major="${EXPECTED_XCODE_MAJOR:-}"
+expected_ios_sdk_major="${EXPECTED_IOS_SDK_MAJOR:-}"
+
+for expected_major in "$expected_xcode_major" "$expected_ios_sdk_major"; do
+  if [[ -n "$expected_major" && ! "$expected_major" =~ ^[0-9]+$ ]]; then
+    echo "Expected major versions must contain only decimal digits: $expected_major" >&2
+    exit 2
+  fi
+done
+
+write_output() {
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+write_summary() {
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+record_mismatch() {
+  mismatch_reasons+=("$1")
+}
+
+version_major() {
+  local version="$1"
+  local major="${version%%.*}"
+  if [[ ! "$major" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+  printf '%s\n' "$major"
+}
+
+mismatch_reasons=()
+actual_image_os="${ImageOS:-missing}"
+actual_image_version="${ImageVersion:-missing}"
+
+if ! actual_macos_version="$(sw_vers -productVersion 2>&1)"; then
+  record_mismatch "sw_vers could not read the macOS version: $actual_macos_version"
+  actual_macos_version="missing"
+fi
+if ! actual_macos_build="$(sw_vers -buildVersion 2>&1)"; then
+  record_mismatch "sw_vers could not read the macOS build: $actual_macos_build"
+  actual_macos_build="missing"
+fi
+if ! actual_architecture="$(uname -m 2>&1)"; then
+  record_mismatch "uname could not read the runner architecture: $actual_architecture"
+  actual_architecture="missing"
+fi
+
+actual_xcode_version="missing"
+actual_xcode_build="missing"
+if xcode_version_output="$(xcodebuild -version 2>&1)"; then
+  actual_xcode_version="$(awk '/^Xcode / { print $2; exit }' <<< "$xcode_version_output")"
+  actual_xcode_build="$(awk '/^Build version / { print $3; exit }' <<< "$xcode_version_output")"
+  if [[ -z "$actual_xcode_version" || -z "$actual_xcode_build" ]]; then
+    record_mismatch "xcodebuild returned an unrecognized version response: $xcode_version_output"
+    actual_xcode_version="${actual_xcode_version:-missing}"
+    actual_xcode_build="${actual_xcode_build:-missing}"
+  fi
+else
+  record_mismatch "xcodebuild could not inspect the selected Xcode: $xcode_version_output"
+fi
+
+actual_iphoneos_sdk="missing"
+if ! actual_iphoneos_sdk="$(xcrun --sdk iphoneos --show-sdk-version 2>&1)"; then
+  record_mismatch "xcrun could not inspect the iphoneos SDK: $actual_iphoneos_sdk"
+  actual_iphoneos_sdk="missing"
+fi
+actual_simulator_sdk="missing"
+if ! actual_simulator_sdk="$(xcrun --sdk iphonesimulator --show-sdk-version 2>&1)"; then
+  record_mismatch "xcrun could not inspect the iphonesimulator SDK: $actual_simulator_sdk"
+  actual_simulator_sdk="missing"
+fi
+runtime_output=""
+if ! runtime_output="$(xcrun simctl list runtimes 2>&1)"; then
+  record_mismatch "simctl could not list installed runtimes: $runtime_output"
+  runtime_output="unavailable"
+fi
+
+if [[ -n "$expected_xcode_major" ]]; then
+  if ! actual_xcode_major="$(version_major "$actual_xcode_version")"; then
+    record_mismatch "Xcode version is not numeric: $actual_xcode_version"
+  elif [[ "$actual_xcode_major" != "$expected_xcode_major" ]]; then
+    record_mismatch "Xcode major expected $expected_xcode_major, found $actual_xcode_version"
+  fi
+fi
+
+if [[ -n "$expected_ios_sdk_major" ]]; then
+  if ! actual_iphoneos_major="$(version_major "$actual_iphoneos_sdk")"; then
+    record_mismatch "iphoneos SDK version is not numeric: $actual_iphoneos_sdk"
+  elif [[ "$actual_iphoneos_major" != "$expected_ios_sdk_major" ]]; then
+    record_mismatch "iphoneos SDK major expected $expected_ios_sdk_major, found $actual_iphoneos_sdk"
+  fi
+  if ! actual_simulator_major="$(version_major "$actual_simulator_sdk")"; then
+    record_mismatch "iphonesimulator SDK version is not numeric: $actual_simulator_sdk"
+  elif [[ "$actual_simulator_major" != "$expected_ios_sdk_major" ]]; then
+    record_mismatch "iphonesimulator SDK major expected $expected_ios_sdk_major, found $actual_simulator_sdk"
+  fi
+fi
+
+echo "Apple toolchain report"
+echo "  runner image: $actual_image_os $actual_image_version"
+echo "  macOS: $actual_macos_version ($actual_macos_build)"
+echo "  architecture: $actual_architecture"
+echo "  Xcode: $actual_xcode_version ($actual_xcode_build)"
+echo "  iphoneos SDK: $actual_iphoneos_sdk"
+echo "  iphonesimulator SDK: $actual_simulator_sdk"
+echo
+echo "$runtime_output"
+
+write_output image-version "$actual_image_version"
+write_output xcode-version "$actual_xcode_version"
+write_output xcode-build "$actual_xcode_build"
+write_output iphoneos-sdk "$actual_iphoneos_sdk"
+write_output iphonesimulator-sdk "$actual_simulator_sdk"
+
+write_summary "## Apple toolchain"
+write_summary ""
+write_summary "| Field | Value |"
+write_summary "| --- | --- |"
+write_summary "| Runner image | \`$actual_image_os $actual_image_version\` |"
+write_summary "| macOS | \`$actual_macos_version ($actual_macos_build)\` |"
+write_summary "| Architecture | \`$actual_architecture\` |"
+write_summary "| Xcode | \`$actual_xcode_version ($actual_xcode_build)\` |"
+write_summary "| iphoneos SDK | \`$actual_iphoneos_sdk\` |"
+write_summary "| iphonesimulator SDK | \`$actual_simulator_sdk\` |"
+
+if (( ${#mismatch_reasons[@]} > 0 )); then
+  write_output classification toolchain-mismatch
+  write_summary ""
+  write_summary "**Classification:** toolchain-mismatch"
+  for reason in "${mismatch_reasons[@]}"; do
+    echo "::error title=Apple toolchain mismatch::$reason"
+    write_summary "- $reason"
+  done
+  exit 1
+fi
+
+classification="reported-toolchain"
+if [[ -n "$expected_xcode_major" || -n "$expected_ios_sdk_major" ]]; then
+  classification="verified-toolchain"
+fi
+write_output classification "$classification"
+write_summary ""
+write_summary "**Classification:** $classification"

--- a/github-actions/ios/report-toolchain/v1/report.sh
+++ b/github-actions/ios/report-toolchain/v1/report.sh
@@ -13,8 +13,10 @@ for expected_major in "$expected_xcode_major" "$expected_ios_sdk_major"; do
 done
 
 write_output() {
+  local value="${2//$'\r'/ }"
+  value="${value//$'\n'/ }"
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+    printf '%s=%s\n' "$1" "$value" >> "$GITHUB_OUTPUT"
   fi
 }
 
@@ -79,10 +81,16 @@ actual_iphoneos_sdk="missing"
 if ! actual_iphoneos_sdk="$(xcrun --sdk iphoneos --show-sdk-version 2>&1)"; then
   record_mismatch "xcrun could not inspect the iphoneos SDK: $actual_iphoneos_sdk"
   actual_iphoneos_sdk="missing"
+elif [[ ! "$actual_iphoneos_sdk" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+  record_mismatch "xcrun returned an unrecognized iphoneos SDK version: $actual_iphoneos_sdk"
+  actual_iphoneos_sdk="missing"
 fi
 actual_simulator_sdk="missing"
 if ! actual_simulator_sdk="$(xcrun --sdk iphonesimulator --show-sdk-version 2>&1)"; then
   record_mismatch "xcrun could not inspect the iphonesimulator SDK: $actual_simulator_sdk"
+  actual_simulator_sdk="missing"
+elif [[ ! "$actual_simulator_sdk" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+  record_mismatch "xcrun returned an unrecognized iphonesimulator SDK version: $actual_simulator_sdk"
   actual_simulator_sdk="missing"
 fi
 runtime_output=""

--- a/github-actions/ios/report-toolchain/v1/report.sh
+++ b/github-actions/ios/report-toolchain/v1/report.sh
@@ -50,6 +50,14 @@ if [[ "$(uname -s 2>/dev/null || true)" != "Darwin" ]]; then
   exit 2
 fi
 
+temporary_root="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/report-ios-toolchain.XXXXXX")"
+sdk_stderr_file="$temporary_root/xcrun.stderr"
+cleanup() {
+  rm -f "$sdk_stderr_file"
+  rmdir "$temporary_root" 2>/dev/null || true
+}
+trap cleanup EXIT
+
 if ! actual_macos_version="$(sw_vers -productVersion 2>&1)"; then
   record_mismatch "sw_vers could not read the macOS version: $actual_macos_version"
   actual_macos_version="missing"
@@ -78,19 +86,25 @@ else
 fi
 
 actual_iphoneos_sdk="missing"
-if ! actual_iphoneos_sdk="$(xcrun --sdk iphoneos --show-sdk-version 2>&1)"; then
-  record_mismatch "xcrun could not inspect the iphoneos SDK: $actual_iphoneos_sdk"
-  actual_iphoneos_sdk="missing"
-elif [[ ! "$actual_iphoneos_sdk" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
-  record_mismatch "xcrun returned an unrecognized iphoneos SDK version: $actual_iphoneos_sdk"
+if actual_iphoneos_sdk="$(xcrun --sdk iphoneos --show-sdk-version 2> "$sdk_stderr_file")"; then
+  if [[ ! "$actual_iphoneos_sdk" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+    record_mismatch "xcrun returned an unrecognized iphoneos SDK version: $actual_iphoneos_sdk"
+    actual_iphoneos_sdk="missing"
+  fi
+else
+  sdk_error="$(< "$sdk_stderr_file")"
+  record_mismatch "xcrun could not inspect the iphoneos SDK: ${sdk_error:-no diagnostic output}"
   actual_iphoneos_sdk="missing"
 fi
 actual_simulator_sdk="missing"
-if ! actual_simulator_sdk="$(xcrun --sdk iphonesimulator --show-sdk-version 2>&1)"; then
-  record_mismatch "xcrun could not inspect the iphonesimulator SDK: $actual_simulator_sdk"
-  actual_simulator_sdk="missing"
-elif [[ ! "$actual_simulator_sdk" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
-  record_mismatch "xcrun returned an unrecognized iphonesimulator SDK version: $actual_simulator_sdk"
+if actual_simulator_sdk="$(xcrun --sdk iphonesimulator --show-sdk-version 2> "$sdk_stderr_file")"; then
+  if [[ ! "$actual_simulator_sdk" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+    record_mismatch "xcrun returned an unrecognized iphonesimulator SDK version: $actual_simulator_sdk"
+    actual_simulator_sdk="missing"
+  fi
+else
+  sdk_error="$(< "$sdk_stderr_file")"
+  record_mismatch "xcrun could not inspect the iphonesimulator SDK: ${sdk_error:-no diagnostic output}"
   actual_simulator_sdk="missing"
 fi
 runtime_output=""

--- a/github-actions/ios/report-toolchain/v1/report.sh
+++ b/github-actions/ios/report-toolchain/v1/report.sh
@@ -25,7 +25,8 @@ write_summary() {
 }
 
 record_mismatch() {
-  mismatch_reasons+=("$1")
+  mismatch_reasons[mismatch_count]="$1"
+  mismatch_count=$((mismatch_count + 1))
 }
 
 version_major() {
@@ -38,8 +39,14 @@ version_major() {
 }
 
 mismatch_reasons=()
+mismatch_count=0
 actual_image_os="${ImageOS:-missing}"
 actual_image_version="${ImageVersion:-missing}"
+
+if [[ "$(uname -s 2>/dev/null || true)" != "Darwin" ]]; then
+  echo "report-toolchain requires a macOS runner" >&2
+  exit 2
+fi
 
 if ! actual_macos_version="$(sw_vers -productVersion 2>&1)"; then
   record_mismatch "sw_vers could not read the macOS version: $actual_macos_version"
@@ -132,13 +139,15 @@ write_summary "| Xcode | \`$actual_xcode_version ($actual_xcode_build)\` |"
 write_summary "| iphoneos SDK | \`$actual_iphoneos_sdk\` |"
 write_summary "| iphonesimulator SDK | \`$actual_simulator_sdk\` |"
 
-if (( ${#mismatch_reasons[@]} > 0 )); then
+if (( mismatch_count > 0 )); then
   write_output classification toolchain-mismatch
   write_summary ""
   write_summary "**Classification:** toolchain-mismatch"
   for reason in "${mismatch_reasons[@]}"; do
-    echo "::error title=Apple toolchain mismatch::$reason"
-    write_summary "- $reason"
+    normalized_reason="${reason//$'\r'/ }"
+    normalized_reason="${normalized_reason//$'\n'/ }"
+    echo "::error title=Apple toolchain mismatch::$normalized_reason"
+    write_summary "- $normalized_reason"
   done
   exit 1
 fi

--- a/github-actions/ios/report-toolchain/v1/test.sh
+++ b/github-actions/ios/report-toolchain/v1/test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/report-ios-toolchain.XXXXXX")"
+trap 'rm -rf "$temporary_root"' EXIT
+
+stub_bin="$temporary_root/bin"
+mkdir -p "$stub_bin"
+
+cat > "$stub_bin/sw_vers" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  -productVersion) printf '%s\n' "${STUB_MACOS_VERSION:-26.5.2}" ;;
+  -buildVersion) printf '%s\n' "${STUB_MACOS_BUILD:-25F84}" ;;
+  *) exit 2 ;;
+esac
+STUB
+
+cat > "$stub_bin/uname" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == "-m" ]] || exit 2
+printf '%s\n' "${STUB_ARCHITECTURE:-arm64}"
+STUB
+
+cat > "$stub_bin/xcodebuild" <<'STUB'
+#!/usr/bin/env bash
+[[ "$1" == "-version" ]] || exit 2
+printf 'Xcode %s\nBuild version %s\n' "${STUB_XCODE_VERSION:-27.0}" "${STUB_XCODE_BUILD:-27A5228h}"
+STUB
+
+cat > "$stub_bin/xcrun" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${STUB_XCRUN_FAIL:-false}" == "true" ]]; then
+  echo "stubbed xcrun failure" >&2
+  exit 1
+fi
+if [[ "$1" == "--sdk" && "$3" == "--show-sdk-version" ]]; then
+  case "$2" in
+    iphoneos) printf '%s\n' "${STUB_IPHONEOS_SDK:-27.0}" ;;
+    iphonesimulator) printf '%s\n' "${STUB_SIMULATOR_SDK:-27.0}" ;;
+    *) exit 2 ;;
+  esac
+elif [[ "$1" == "simctl" && "$2" == "list" && "$3" == "runtimes" ]]; then
+  printf '%s\n' 'iOS 27.0 (27.0 - 24A999) - com.apple.CoreSimulator.SimRuntime.iOS-27-0'
+else
+  exit 2
+fi
+STUB
+
+chmod +x "$stub_bin/sw_vers" "$stub_bin/uname" "$stub_bin/xcodebuild" "$stub_bin/xcrun"
+
+run_report() {
+  local case_name="$1"
+  shift
+  local case_root="$temporary_root/$case_name"
+  mkdir -p "$case_root"
+  env \
+    PATH="$stub_bin:/usr/bin:/bin" \
+    ImageOS=macos26 \
+    ImageVersion=20260810.0090.1 \
+    GITHUB_OUTPUT="$case_root/output" \
+    GITHUB_STEP_SUMMARY="$case_root/summary" \
+    "$@" \
+    bash "$script_dir/report.sh"
+}
+
+run_report verified EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=27
+grep -qx 'classification=verified-toolchain' "$temporary_root/verified/output"
+grep -Fq "Xcode | \`27.0 (27A5228h)\`" "$temporary_root/verified/summary"
+
+run_report report-only EXPECTED_XCODE_MAJOR= EXPECTED_IOS_SDK_MAJOR=
+grep -qx 'classification=reported-toolchain' "$temporary_root/report-only/output"
+
+if run_report wrong-xcode EXPECTED_XCODE_MAJOR=26 EXPECTED_IOS_SDK_MAJOR=27; then
+  echo "Expected the Xcode major mismatch to fail." >&2
+  exit 1
+fi
+grep -qx 'classification=toolchain-mismatch' "$temporary_root/wrong-xcode/output"
+grep -Fq 'Xcode major expected 26, found 27.0' "$temporary_root/wrong-xcode/summary"
+
+if run_report wrong-sdk EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=26; then
+  echo "Expected the iOS SDK major mismatch to fail." >&2
+  exit 1
+fi
+grep -Fq 'iphoneos SDK major expected 26, found 27.0' "$temporary_root/wrong-sdk/summary"
+grep -Fq 'iphonesimulator SDK major expected 26, found 27.0' "$temporary_root/wrong-sdk/summary"
+
+if run_report inspection-failure EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=27 STUB_XCRUN_FAIL=true; then
+  echo "Expected toolchain inspection failure to fail closed." >&2
+  exit 1
+fi
+grep -qx 'classification=toolchain-mismatch' "$temporary_root/inspection-failure/output"
+
+if run_report invalid-input EXPECTED_XCODE_MAJOR=twenty-seven EXPECTED_IOS_SDK_MAJOR=27; then
+  echo "Expected invalid major input to fail." >&2
+  exit 1
+fi
+
+echo "report-toolchain tests passed"

--- a/github-actions/ios/report-toolchain/v1/test.sh
+++ b/github-actions/ios/report-toolchain/v1/test.sh
@@ -104,6 +104,16 @@ if run_report inspection-failure EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=
 fi
 grep -qx 'classification=toolchain-mismatch' "$temporary_root/inspection-failure/output"
 
+if run_report noisy-sdk EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=27 STUB_IPHONEOS_SDK=$'warning\n27.0'; then
+  echo "Expected multiline SDK output to fail closed." >&2
+  exit 1
+fi
+grep -qx 'classification=toolchain-mismatch' "$temporary_root/noisy-sdk/output"
+if grep -qx '27.0' "$temporary_root/noisy-sdk/output"; then
+  echo "Multiline command output injected a GitHub output line." >&2
+  exit 1
+fi
+
 if run_report xcodebuild-failure EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=27 STUB_XCODEBUILD_FAIL=true; then
   echo "Expected xcodebuild inspection failure to fail closed." >&2
   exit 1

--- a/github-actions/ios/report-toolchain/v1/test.sh
+++ b/github-actions/ios/report-toolchain/v1/test.sh
@@ -20,13 +20,24 @@ STUB
 
 cat > "$stub_bin/uname" <<'STUB'
 #!/usr/bin/env bash
-[[ "$1" == "-m" ]] || exit 2
-printf '%s\n' "${STUB_ARCHITECTURE:-arm64}"
+case "$1" in
+  -s) printf '%s\n' Darwin ;;
+  -m) printf '%s\n' "${STUB_ARCHITECTURE:-arm64}" ;;
+  *) exit 2 ;;
+esac
 STUB
 
 cat > "$stub_bin/xcodebuild" <<'STUB'
 #!/usr/bin/env bash
 [[ "$1" == "-version" ]] || exit 2
+if [[ "${STUB_XCODEBUILD_FAIL:-false}" == "true" ]]; then
+  echo "stubbed xcodebuild failure" >&2
+  exit 1
+fi
+if [[ "${STUB_XCODEBUILD_GARBAGE:-false}" == "true" ]]; then
+  echo "not an Xcode version"
+  exit 0
+fi
 printf 'Xcode %s\nBuild version %s\n' "${STUB_XCODE_VERSION:-27.0}" "${STUB_XCODE_BUILD:-27A5228h}"
 STUB
 
@@ -92,6 +103,20 @@ if run_report inspection-failure EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=
   exit 1
 fi
 grep -qx 'classification=toolchain-mismatch' "$temporary_root/inspection-failure/output"
+
+if run_report xcodebuild-failure EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=27 STUB_XCODEBUILD_FAIL=true; then
+  echo "Expected xcodebuild inspection failure to fail closed." >&2
+  exit 1
+fi
+grep -qx 'classification=toolchain-mismatch' "$temporary_root/xcodebuild-failure/output"
+grep -Fq 'xcodebuild could not inspect' "$temporary_root/xcodebuild-failure/summary"
+
+if run_report xcodebuild-garbage EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=27 STUB_XCODEBUILD_GARBAGE=true; then
+  echo "Expected unparseable xcodebuild output to fail closed." >&2
+  exit 1
+fi
+grep -qx 'classification=toolchain-mismatch' "$temporary_root/xcodebuild-garbage/output"
+grep -Fq 'xcodebuild returned an unrecognized version response' "$temporary_root/xcodebuild-garbage/summary"
 
 if run_report invalid-input EXPECTED_XCODE_MAJOR=twenty-seven EXPECTED_IOS_SDK_MAJOR=27; then
   echo "Expected invalid major input to fail." >&2

--- a/github-actions/ios/report-toolchain/v1/test.sh
+++ b/github-actions/ios/report-toolchain/v1/test.sh
@@ -48,6 +48,9 @@ if [[ "${STUB_XCRUN_FAIL:-false}" == "true" ]]; then
   exit 1
 fi
 if [[ "$1" == "--sdk" && "$3" == "--show-sdk-version" ]]; then
+  if [[ "${STUB_XCRUN_SDK_NOTE:-false}" == "true" ]]; then
+    echo "xcrun: note: using the selected SDK" >&2
+  fi
   case "$2" in
     iphoneos) printf '%s\n' "${STUB_IPHONEOS_SDK:-27.0}" ;;
     iphonesimulator) printf '%s\n' "${STUB_SIMULATOR_SDK:-27.0}" ;;
@@ -81,6 +84,11 @@ run_report verified EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=27
 grep -qx 'classification=verified-toolchain' "$temporary_root/verified/output"
 grep -Fq "Xcode | \`27.0 (27A5228h)\`" "$temporary_root/verified/summary"
 
+run_report sdk-stderr-note EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=27 STUB_XCRUN_SDK_NOTE=true
+grep -qx 'classification=verified-toolchain' "$temporary_root/sdk-stderr-note/output"
+grep -qx 'iphoneos-sdk=27.0' "$temporary_root/sdk-stderr-note/output"
+grep -qx 'iphonesimulator-sdk=27.0' "$temporary_root/sdk-stderr-note/output"
+
 run_report report-only EXPECTED_XCODE_MAJOR= EXPECTED_IOS_SDK_MAJOR=
 grep -qx 'classification=reported-toolchain' "$temporary_root/report-only/output"
 
@@ -103,6 +111,8 @@ if run_report inspection-failure EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=
   exit 1
 fi
 grep -qx 'classification=toolchain-mismatch' "$temporary_root/inspection-failure/output"
+grep -Fq 'xcrun could not inspect the iphoneos SDK: stubbed xcrun failure' "$temporary_root/inspection-failure/summary"
+grep -Fq 'xcrun could not inspect the iphonesimulator SDK: stubbed xcrun failure' "$temporary_root/inspection-failure/summary"
 
 if run_report noisy-sdk EXPECTED_XCODE_MAJOR=27 EXPECTED_IOS_SDK_MAJOR=27 STUB_IPHONEOS_SDK=$'warning\n27.0'; then
   echo "Expected multiline SDK output to fail closed." >&2


### PR DESCRIPTION
## Summary

- add one shared Apple toolchain report for stable and preview runners
- verify requested Xcode and iOS SDK major families without pinning a floating preview image
- record the hosted image, macOS, architecture, exact Xcode build, SDKs, and runtimes
- fail closed on missing, malformed, or mismatched toolchain data

## Role in the rollout

This action is the shared reporting and fail-closed verification dependency for the native, Flutter, and Expo Xcode 27 preview workflows. The action does not schedule or duplicate builds.

Each consumer keeps its existing stable-Xcode PR and release CI. Xcode 27 preview compilation runs once nightly on staggered schedules, plus manual dispatch and validation when the preview workflow itself changes. Exact beta-image checks stay in separately titled test-only PRs and never merge.

## Validation

- hosted `shell-tests` and `macos-bash-tests` pass at exact head
- macOS Bash 3.2.57 and Bash 5 focused tests pass
- composite-action smoke test, Xcode command-failure cases, multiline-output sanitization, shellcheck, Bash syntax, and actionlint pass
- final Claude Opus exact-head review found no P1/P2 blocker

## Release impact

CI-only. No SDK or package release. Consumer preview workflows are nightly and do not add per-commit Xcode 27 jobs to ordinary pull requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only GitHub Actions and shell scripts; no application runtime, SDK release, or production deployment paths.
> 
> **Overview**
> Adds a reusable **Report iOS toolchain** composite action under `github-actions/ios/report-toolchain/v1` so macOS workflows can record the hosted Apple stack and optionally assert Xcode and iOS SDK **major** versions without pinning a floating preview image.
> 
> The action runs `report.sh` on Darwin runners to collect runner image metadata, macOS build, architecture, `xcodebuild` version/build, `iphoneos`/`iphonesimulator` SDKs, and simulator runtimes. It writes GitHub step outputs and a markdown summary, classifying the result as `reported-toolchain`, `verified-toolchain`, or `toolchain-mismatch`. **Inspection or assertion failures fail closed** (non-zero exit, `::error` annotations).
> 
> `test.sh` exercises the reporter with stubbed `sw_vers`, `xcodebuild`, and `xcrun`, covering verify-only, report-only, mismatches, command failures, multiline output sanitization, and invalid inputs. A new **`ios-actions-test`** workflow runs `bash -n`, `shellcheck`, the stub tests on Ubuntu, and on `macos-26` runs tests under system Bash plus a smoke test of the composite action outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f11fac467e97aa142d954939f5899a61178ffcfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

