### PR TITLE
ci(ios): add reusable simulator launch smoke action

### DIFF
--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -202,7 +202,8 @@ jobs:
           CRASH_OUTCOME: ${{ steps.crash-smoke.outcome }}
         run: |
           test "$CRASH_OUTCOME" = 'failure'
-          grep -Fq 'did not survive 2 seconds' "$RUNNER_TEMP/ios-simulator-launch-crash.log"
+          grep -Fq 'exited or changed identity after 1s of the 2s survival window' \
+            "$RUNNER_TEMP/ios-simulator-launch-crash.log"
 
       - name: Upload simulator launch diagnostics
         if: failure()

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -37,7 +37,7 @@ jobs:
 
   macos-bash-tests:
     runs-on: macos-26
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -87,6 +87,7 @@ jobs:
                   #if CRASH_ON_CONNECT
                   NSLog("CIO_LAUNCH_SMOKE_CRASH_FIXTURE")
                   DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                      NSLog("CIO_LAUNCH_SMOKE_CRASH_FIXTURE_FATAL")
                       fatalError("intentional launch-smoke crash")
                   }
                   #endif
@@ -183,7 +184,7 @@ jobs:
         with:
           app-path: ${{ steps.launch-fixture.outputs.app-path }}
           expected-ios-major: ${{ steps.launch-fixture.outputs.ios-major }}
-          survival-seconds: '15'
+          survival-seconds: '5'
           log-path: ${{ runner.temp }}/ios-simulator-launch-smoke.log
 
       - name: Verify simulator launch outputs
@@ -216,6 +217,8 @@ jobs:
           grep -Fq '===== Simulator log for' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"
           grep -Fq 'CIO_LAUNCH_SMOKE_CRASH_FIXTURE' \
+            "$RUNNER_TEMP/ios-simulator-launch-crash.log"
+          grep -Fq 'CIO_LAUNCH_SMOKE_CRASH_FIXTURE_FATAL' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"
 
       - name: Upload simulator launch diagnostics

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -37,6 +37,7 @@ jobs:
 
   macos-bash-tests:
     runs-on: macos-26
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -147,8 +148,28 @@ jobs:
           echo "ios-major=$ios_major" >> "$GITHUB_OUTPUT"
 
       - name: Smoke-test simulator install, launch, and process survival
+        id: launch-smoke
         uses: ./github-actions/ios/launch-simulator-app/v1
         with:
           app-path: ${{ steps.launch-fixture.outputs.app-path }}
           expected-ios-major: ${{ steps.launch-fixture.outputs.ios-major }}
           survival-seconds: '2'
+
+      - name: Verify simulator launch outputs
+        env:
+          CLASSIFICATION: ${{ steps.launch-smoke.outputs.classification }}
+          FAILURE_REASON: ${{ steps.launch-smoke.outputs.failure-reason }}
+          LAUNCHED_PID: ${{ steps.launch-smoke.outputs.launched-pid }}
+        run: |
+          test "$CLASSIFICATION" = 'launch-passed'
+          test "$FAILURE_REASON" = 'none'
+          [[ "$LAUNCHED_PID" =~ ^[1-9][0-9]*$ ]]
+
+      - name: Upload simulator launch diagnostics
+        if: failure() && steps.launch-smoke.outputs.log-path != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ios-simulator-launch-smoke-log
+          path: ${{ steps.launch-smoke.outputs.log-path }}
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -214,9 +214,11 @@ jobs:
           test "$CRASH_OUTCOME" = 'failure'
           grep -Fq 'exited, became non-runnable, or changed identity after' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"
-          grep -Fq '===== Simulator log for' \
+          grep -Fq '===== App log for' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"
-          grep -Fq 'CIO_LAUNCH_SMOKE_CRASH_FIXTURE' \
+          grep -Fq '===== Simulator diagnostics for' \
+            "$RUNNER_TEMP/ios-simulator-launch-crash.log"
+          grep -Eq 'CIO_LAUNCH_SMOKE_CRASH_FIXTURE([^_[:alnum:]]|$)' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"
           grep -Fq 'CIO_LAUNCH_SMOKE_CRASH_FIXTURE_FATAL' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -168,10 +168,10 @@ jobs:
           [[ "$LAUNCHED_PID" =~ ^[1-9][0-9]*$ ]]
 
       - name: Upload simulator launch diagnostics
-        if: failure() && steps.launch-smoke.outputs.log-path != ''
+        if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-simulator-launch-smoke-log
-          path: ${{ steps.launch-smoke.outputs.log-path }}
-          if-no-files-found: error
+          path: ${{ runner.temp }}/ios-simulator-launch-smoke.log
+          if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -149,8 +149,8 @@ jobs:
           </dict>
           </plist>
           PLIST
+          [[ -n "${RUNNER_TEMP:-}" && "$RUNNER_TEMP" = /* && -d "$RUNNER_TEMP" ]]
           crash_app_path="$RUNNER_TEMP/LaunchCrash.app"
-          test "$crash_app_path" = "$RUNNER_TEMP/LaunchCrash.app"
           rm -rf -- "$crash_app_path"
           cp -R "$app_path" "$crash_app_path"
           rm -f -- "$crash_app_path/LaunchSmoke"
@@ -207,7 +207,7 @@ jobs:
           CRASH_OUTCOME: ${{ steps.crash-smoke.outcome }}
         run: |
           test "$CRASH_OUTCOME" = 'failure'
-          grep -Fq 'exited or changed identity after' \
+          grep -Fq 'exited, became non-runnable, or changed identity after' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"
           grep -Fq '===== Simulator log for' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -148,6 +148,7 @@ jobs:
           PLIST
           crash_app_path="$RUNNER_TEMP/LaunchCrash.app"
           cp -R "$app_path" "$crash_app_path"
+          rm -f -- "$crash_app_path/LaunchSmoke"
           xcrun --sdk iphonesimulator swiftc \
             -parse-as-library \
             -DCRASH_ON_CONNECT \
@@ -173,7 +174,7 @@ jobs:
         with:
           app-path: ${{ steps.launch-fixture.outputs.app-path }}
           expected-ios-major: ${{ steps.launch-fixture.outputs.ios-major }}
-          survival-seconds: '2'
+          survival-seconds: '15'
           log-path: ${{ runner.temp }}/ios-simulator-launch-smoke.log
 
       - name: Verify simulator launch outputs
@@ -197,12 +198,13 @@ jobs:
           log-path: ${{ runner.temp }}/ios-simulator-launch-crash.log
 
       - name: Verify a real launch crash is rejected
-        if: always()
         env:
           CRASH_OUTCOME: ${{ steps.crash-smoke.outcome }}
         run: |
           test "$CRASH_OUTCOME" = 'failure'
-          grep -Fq 'exited or changed identity after 1s of the 2s survival window' \
+          grep -Fq 'exited or changed identity after' \
+            "$RUNNER_TEMP/ios-simulator-launch-crash.log"
+          grep -Fq '===== Simulator log for' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"
 
       - name: Upload simulator launch diagnostics

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -85,7 +85,10 @@ jobs:
                   options connectionOptions: UIScene.ConnectionOptions
               ) {
                   #if CRASH_ON_CONNECT
-                  fatalError("intentional launch-smoke crash")
+                  NSLog("CIO_LAUNCH_SMOKE_CRASH_FIXTURE")
+                  DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                      fatalError("intentional launch-smoke crash")
+                  }
                   #endif
                   guard let windowScene = scene as? UIWindowScene else { return }
                   let window = UIWindow(windowScene: windowScene)
@@ -207,6 +210,8 @@ jobs:
           grep -Fq 'exited or changed identity after' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"
           grep -Fq '===== Simulator log for' \
+            "$RUNNER_TEMP/ios-simulator-launch-crash.log"
+          grep -Fq 'CIO_LAUNCH_SMOKE_CRASH_FIXTURE' \
             "$RUNNER_TEMP/ios-simulator-launch-crash.log"
 
       - name: Upload simulator launch diagnostics

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -154,6 +154,7 @@ jobs:
           app-path: ${{ steps.launch-fixture.outputs.app-path }}
           expected-ios-major: ${{ steps.launch-fixture.outputs.ios-major }}
           survival-seconds: '2'
+          log-path: ${{ runner.temp }}/ios-simulator-launch-smoke.log
 
       - name: Verify simulator launch outputs
         env:
@@ -166,10 +167,10 @@ jobs:
           [[ "$LAUNCHED_PID" =~ ^[1-9][0-9]*$ ]]
 
       - name: Upload simulator launch diagnostics
-        if: failure() && steps.launch-smoke.outputs.log-path != ''
+        if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-simulator-launch-smoke-log
-          path: ${{ steps.launch-smoke.outputs.log-path }}
+          path: ${{ runner.temp }}/ios-simulator-launch-smoke.log
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -61,3 +61,94 @@ jobs:
           test -n "$XCODE_VERSION"
           test -n "$IPHONEOS_SDK"
           test -n "$IPHONESIMULATOR_SDK"
+
+      - name: Build a minimal UIScene simulator app
+        id: launch-fixture
+        shell: bash
+        env:
+          IPHONESIMULATOR_SDK: ${{ steps.reporter.outputs.iphonesimulator-sdk }}
+        run: |
+          set -euo pipefail
+          app_path="$RUNNER_TEMP/LaunchSmoke.app"
+          source_path="$RUNNER_TEMP/LaunchSmoke.swift"
+          mkdir -p "$app_path"
+          cat > "$source_path" <<'SWIFT'
+          import UIKit
+
+          final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+              var window: UIWindow?
+
+              func scene(
+                  _ scene: UIScene,
+                  willConnectTo session: UISceneSession,
+                  options connectionOptions: UIScene.ConnectionOptions
+              ) {
+                  guard let windowScene = scene as? UIWindowScene else { return }
+                  let window = UIWindow(windowScene: windowScene)
+                  window.rootViewController = UIViewController()
+                  window.makeKeyAndVisible()
+                  self.window = window
+              }
+          }
+
+          @main
+          final class AppDelegate: UIResponder, UIApplicationDelegate {
+              func application(
+                  _ application: UIApplication,
+                  configurationForConnecting connectingSceneSession: UISceneSession,
+                  options: UIScene.ConnectionOptions
+              ) -> UISceneConfiguration {
+                  UISceneConfiguration(
+                      name: "Default Configuration",
+                      sessionRole: connectingSceneSession.role
+                  )
+              }
+          }
+          SWIFT
+          sdk_path="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+          architecture="$(uname -m)"
+          xcrun --sdk iphonesimulator swiftc \
+            -module-name LaunchSmoke \
+            -target "${architecture}-apple-ios15.0-simulator" \
+            -sdk "$sdk_path" \
+            "$source_path" \
+            -o "$app_path/LaunchSmoke"
+          cat > "$app_path/Info.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleExecutable</key><string>LaunchSmoke</string>
+            <key>CFBundleIdentifier</key><string>io.customer.mobile-ci-tools.launch-smoke</string>
+            <key>CFBundleName</key><string>LaunchSmoke</string>
+            <key>CFBundlePackageType</key><string>APPL</string>
+            <key>CFBundleShortVersionString</key><string>1.0</string>
+            <key>CFBundleVersion</key><string>1</string>
+            <key>DTSDKName</key><string>iphonesimulator${IPHONESIMULATOR_SDK}</string>
+            <key>MinimumOSVersion</key><string>15.0</string>
+            <key>UIApplicationSceneManifest</key>
+            <dict>
+              <key>UIApplicationSupportsMultipleScenes</key><false/>
+              <key>UISceneConfigurations</key>
+              <dict>
+                <key>UIWindowSceneSessionRoleApplication</key>
+                <array><dict>
+                  <key>UISceneConfigurationName</key><string>Default Configuration</string>
+                  <key>UISceneDelegateClassName</key><string>LaunchSmoke.SceneDelegate</string>
+                </dict></array>
+              </dict>
+            </dict>
+          </dict>
+          </plist>
+          PLIST
+          ios_major="${IPHONESIMULATOR_SDK%%.*}"
+          [[ "$ios_major" =~ ^[1-9][0-9]*$ ]]
+          echo "app-path=$app_path" >> "$GITHUB_OUTPUT"
+          echo "ios-major=$ios_major" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-test simulator install, launch, and process survival
+        uses: ./github-actions/ios/launch-simulator-app/v1
+        with:
+          app-path: ${{ steps.launch-fixture.outputs.app-path }}
+          expected-ios-major: ${{ steps.launch-fixture.outputs.ios-major }}
+          survival-seconds: '2'

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -22,15 +22,18 @@ jobs:
 
       - name: Check shell syntax
         run: |
-          for script in github-actions/ios/report-toolchain/v1/*.sh; do
+          for script in github-actions/ios/*/v1/*.sh; do
             bash -n "$script"
           done
 
       - name: Run shellcheck
-        run: shellcheck github-actions/ios/report-toolchain/v1/*.sh
+        run: shellcheck github-actions/ios/*/v1/*.sh
 
       - name: Test toolchain reporter
         run: bash github-actions/ios/report-toolchain/v1/test.sh
+
+      - name: Test simulator launch sentinel
+        run: bash github-actions/ios/launch-simulator-app/v1/test.sh
 
   macos-bash-tests:
     runs-on: macos-26
@@ -39,6 +42,9 @@ jobs:
 
       - name: Test with the macOS system Bash
         run: /bin/bash github-actions/ios/report-toolchain/v1/test.sh
+
+      - name: Test simulator launch sentinel with the macOS system Bash
+        run: /bin/bash github-actions/ios/launch-simulator-app/v1/test.sh
 
       - name: Smoke-test the composite action on the hosted toolchain
         id: reporter

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -131,9 +131,13 @@ jobs:
             <key>CFBundleName</key><string>LaunchSmoke</string>
             <key>CFBundlePackageType</key><string>APPL</string>
             <key>CFBundleShortVersionString</key><string>1.0</string>
+            <key>CFBundleSupportedPlatforms</key><array><string>iPhoneSimulator</string></array>
             <key>CFBundleVersion</key><string>1</string>
+            <key>DTPlatformName</key><string>iphonesimulator</string>
             <key>DTSDKName</key><string>iphonesimulator${IPHONESIMULATOR_SDK}</string>
+            <key>LSRequiresIPhoneOS</key><true/>
             <key>MinimumOSVersion</key><string>15.0</string>
+            <key>UIDeviceFamily</key><array><integer>1</integer></array>
             <key>UIApplicationSceneManifest</key>
             <dict>
               <key>UIApplicationSupportsMultipleScenes</key><false/>

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -147,6 +147,8 @@ jobs:
           </plist>
           PLIST
           crash_app_path="$RUNNER_TEMP/LaunchCrash.app"
+          test "$crash_app_path" = "$RUNNER_TEMP/LaunchCrash.app"
+          rm -rf -- "$crash_app_path"
           cp -R "$app_path" "$crash_app_path"
           rm -f -- "$crash_app_path/LaunchSmoke"
           xcrun --sdk iphonesimulator swiftc \
@@ -194,7 +196,7 @@ jobs:
         with:
           app-path: ${{ steps.launch-fixture.outputs.crash-app-path }}
           expected-ios-major: ${{ steps.launch-fixture.outputs.ios-major }}
-          survival-seconds: '2'
+          survival-seconds: '15'
           log-path: ${{ runner.temp }}/ios-simulator-launch-crash.log
 
       - name: Verify a real launch crash is rejected

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -84,6 +84,9 @@ jobs:
                   willConnectTo session: UISceneSession,
                   options connectionOptions: UIScene.ConnectionOptions
               ) {
+                  #if CRASH_ON_CONNECT
+                  fatalError("intentional launch-smoke crash")
+                  #endif
                   guard let windowScene = scene as? UIWindowScene else { return }
                   let window = UIWindow(windowScene: windowScene)
                   window.rootViewController = UIViewController()
@@ -143,10 +146,26 @@ jobs:
           </dict>
           </plist>
           PLIST
+          crash_app_path="$RUNNER_TEMP/LaunchCrash.app"
+          cp -R "$app_path" "$crash_app_path"
+          xcrun --sdk iphonesimulator swiftc \
+            -parse-as-library \
+            -DCRASH_ON_CONNECT \
+            -module-name LaunchSmoke \
+            -target "${architecture}-apple-ios15.0-simulator" \
+            -sdk "$sdk_path" \
+            "$source_path" \
+            -o "$crash_app_path/LaunchCrash"
+          /usr/libexec/PlistBuddy -c 'Set :CFBundleExecutable LaunchCrash' "$crash_app_path/Info.plist"
+          /usr/libexec/PlistBuddy -c 'Set :CFBundleIdentifier io.customer.mobile-ci-tools.launch-crash' "$crash_app_path/Info.plist"
+          /usr/libexec/PlistBuddy -c 'Set :CFBundleName LaunchCrash' "$crash_app_path/Info.plist"
           ios_major="${IPHONESIMULATOR_SDK%%.*}"
           [[ "$ios_major" =~ ^[1-9][0-9]*$ ]]
-          echo "app-path=$app_path" >> "$GITHUB_OUTPUT"
-          echo "ios-major=$ios_major" >> "$GITHUB_OUTPUT"
+          {
+            echo "app-path=$app_path"
+            echo "crash-app-path=$crash_app_path"
+            echo "ios-major=$ios_major"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Smoke-test simulator install, launch, and process survival
         id: launch-smoke
@@ -167,11 +186,31 @@ jobs:
           test "$FAILURE_REASON" = 'none'
           [[ "$LAUNCHED_PID" =~ ^[1-9][0-9]*$ ]]
 
+      - name: Smoke-test a real launch crash
+        id: crash-smoke
+        continue-on-error: true
+        uses: ./github-actions/ios/launch-simulator-app/v1
+        with:
+          app-path: ${{ steps.launch-fixture.outputs.crash-app-path }}
+          expected-ios-major: ${{ steps.launch-fixture.outputs.ios-major }}
+          survival-seconds: '2'
+          log-path: ${{ runner.temp }}/ios-simulator-launch-crash.log
+
+      - name: Verify a real launch crash is rejected
+        if: always()
+        env:
+          CRASH_OUTCOME: ${{ steps.crash-smoke.outcome }}
+        run: |
+          test "$CRASH_OUTCOME" = 'failure'
+          grep -Fq 'did not survive 2 seconds' "$RUNNER_TEMP/ios-simulator-launch-crash.log"
+
       - name: Upload simulator launch diagnostics
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-simulator-launch-smoke-log
-          path: ${{ runner.temp }}/ios-simulator-launch-smoke.log
+          path: |
+            ${{ runner.temp }}/ios-simulator-launch-smoke.log
+            ${{ runner.temp }}/ios-simulator-launch-crash.log
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -109,6 +109,7 @@ jobs:
           sdk_path="$(xcrun --sdk iphonesimulator --show-sdk-path)"
           architecture="$(uname -m)"
           xcrun --sdk iphonesimulator swiftc \
+            -parse-as-library \
             -module-name LaunchSmoke \
             -target "${architecture}-apple-ios15.0-simulator" \
             -sdk "$sdk_path" \
@@ -167,7 +168,7 @@ jobs:
           [[ "$LAUNCHED_PID" =~ ^[1-9][0-9]*$ ]]
 
       - name: Upload simulator launch diagnostics
-        if: failure()
+        if: failure() && steps.launch-smoke.outcome != 'skipped'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-simulator-launch-smoke-log

--- a/.github/workflows/ios-actions-test.yml
+++ b/.github/workflows/ios-actions-test.yml
@@ -168,10 +168,10 @@ jobs:
           [[ "$LAUNCHED_PID" =~ ^[1-9][0-9]*$ ]]
 
       - name: Upload simulator launch diagnostics
-        if: failure() && steps.launch-smoke.outcome != 'skipped'
+        if: failure() && steps.launch-smoke.outputs.log-path != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-simulator-launch-smoke-log
-          path: ${{ runner.temp }}/ios-simulator-launch-smoke.log
+          path: ${{ steps.launch-smoke.outputs.log-path }}
           if-no-files-found: error
           retention-days: 7

--- a/README.md
+++ b/README.md
@@ -32,13 +32,17 @@ that could not yet be determined use `unknown`. Consumers should pass a known
 `log-path`, then add an `if: failure()` artifact-upload step for that same path
 with `if-no-files-found: ignore`. A failed composite action is not required to
 propagate its mapped outputs, so diagnostics upload must not depend on the
-`log-path` output. Use a distinct path for each invocation because the action
+`log-path` output. If the action uses `continue-on-error: true`, gate that upload
+on `steps.<id>.outcome == 'failure'` because the job-level `failure()` predicate
+remains false. Use a distinct path for each invocation because the action
 truncates its requested log before launch. The action intentionally does not replay app-controlled
 simulator logs through the GitHub command parser. Consumers must also set a
 job-level `timeout-minutes`, because CoreSimulator commands have no portable
 macOS command-level timeout. The requested runtime major must match the built
 app's normalized `DTSDKName` major. The app must use an Apple-conforming bundle
 identifier containing only ASCII letters, digits, hyphens, and periods.
+Hosted macOS runners provide the required Python 3, `xcrun`, `ps`, `sleep`, and
+`/usr/libexec/PlistBuddy` tools. A self-hosted runner must provide the same tools.
 
 The action assumes exclusive use of the selected simulator for the tested
 bundle identifier. Concurrent jobs sharing one simulator and bundle identifier

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ truncates its requested log before launch. The action intentionally does not rep
 simulator logs through the GitHub command parser. Consumers must also set a
 job-level `timeout-minutes`, because CoreSimulator commands have no portable
 macOS command-level timeout. The requested runtime major must match the built
-app's normalized `DTSDKName` major.
+app's normalized `DTSDKName` major. The app must use an Apple-conforming bundle
+identifier containing only ASCII letters, digits, hyphens, and periods.
 
 The action assumes exclusive use of the selected simulator for the tested
 bundle identifier. Concurrent jobs sharing one simulator and bundle identifier

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ output. The `failure-reason` output distinguishes invalid inputs and products,
 SDK/runtime mismatch, runtime selection or boot failure, install failure,
 launch rejection, failure to survive, and unexpected command failure. Outputs
 that could not yet be determined use `unknown`; a failure before the log is
-initialized can leave other outputs unset. Consumers should add an `if: failure()` artifact-upload step when that
-output is non-empty; the action intentionally does not replay app-controlled
+initialized can leave other outputs unset. Consumers should add an `if: failure()` artifact-upload step when the
+`log-path` output is non-empty; the action intentionally does not replay app-controlled
 simulator logs through the GitHub command parser. Consumers must also set a
 job-level `timeout-minutes`, because CoreSimulator commands have no portable
 macOS command-level timeout. The requested runtime major must match the built

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ that could not yet be determined use `unknown`. Consumers should pass a known
 `log-path`, then add an `if: failure()` artifact-upload step for that same path
 with `if-no-files-found: ignore`. A failed composite action is not required to
 propagate its mapped outputs, so diagnostics upload must not depend on the
-`log-path` output. The action intentionally does not replay app-controlled
+`log-path` output. Use a distinct path for each invocation because the action
+truncates its requested log before launch. The action intentionally does not replay app-controlled
 simulator logs through the GitHub command parser. Consumers must also set a
 job-level `timeout-minutes`, because CoreSimulator commands have no portable
 macOS command-level timeout. The requested runtime major must match the built

--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ sentinel, not evidence of lifecycle callbacks, push delivery, signing, or App
 Store compatibility.
 
 The action terminates and uninstalls the app after the smoke test. On failure,
-launch and survival failures write simulator diagnostics to its `log-path`
-output. The `failure-reason` output distinguishes invalid inputs and products,
+launch and survival failures write simulator diagnostics to the explicit
+`log-path` input. The `failure-reason` output distinguishes invalid inputs and products,
 SDK/runtime mismatch, runtime selection or boot failure, install failure,
 launch rejection, failure to survive, and unexpected command failure. Outputs
-that could not yet be determined use `unknown`. Consumers should add an `if: failure()` artifact-upload step when the
-`log-path` output is non-empty; the action intentionally does not replay app-controlled
+that could not yet be determined use `unknown`. Consumers should pass a known
+`log-path`, then add an `if: failure()` artifact-upload step for that same path
+with `if-no-files-found: ignore`. A failed composite action is not required to
+propagate its mapped outputs, so diagnostics upload must not depend on the
+`log-path` output. The action intentionally does not replay app-controlled
 simulator logs through the GitHub command parser. Consumers must also set a
 job-level `timeout-minutes`, because CoreSimulator commands have no portable
 macOS command-level timeout. The requested runtime major must match the built

--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ This repository centralizes **GitHub Actions, workflows, Fastlane lanes, and aut
 - 🚀 **GitHub Actions & Workflows** – Automate builds, tests, and deployments
 - 📱 **Fastlane Lanes** – Manage SDK versioning, sample app builds, and releases
 - 🔧 **Utility Scripts** – Support automation for CI/CD tasks
+
+### iOS simulator launch smoke
+
+`github-actions/ios/launch-simulator-app/v1` installs an existing simulator
+`.app`, launches it on an available iPhone runtime, and fails when the process
+does not remain alive for the configured survival window. It is a launch-crash
+sentinel, not evidence of lifecycle callbacks, push delivery, signing, or App
+Store compatibility.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ job-level `timeout-minutes`, because CoreSimulator commands have no portable
 macOS command-level timeout. The requested runtime major must match the built
 app's normalized `DTSDKName` major.
 
+The action assumes exclusive use of the selected simulator for the tested
+bundle identifier. Concurrent jobs sharing one simulator and bundle identifier
+can terminate or uninstall each other's fixture; serialize those jobs or use
+isolated simulators.
+
 The failure log contains the tested app's own unified-log output. Consumers
 should use short artifact retention and must not exercise fixtures that emit
 real customer profiles, device tokens, or other sensitive data.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ launch and survival failures write simulator diagnostics to its `log-path`
 output. The `failure-reason` output distinguishes invalid inputs and products,
 SDK/runtime mismatch, runtime selection or boot failure, install failure,
 launch rejection, failure to survive, and unexpected command failure. Outputs
-that could not yet be determined use `unknown`; a failure before the log is
-initialized can leave other outputs unset. Consumers should add an `if: failure()` artifact-upload step when the
+that could not yet be determined use `unknown`. Consumers should add an `if: failure()` artifact-upload step when the
 `log-path` output is non-empty; the action intentionally does not replay app-controlled
 simulator logs through the GitHub command parser. Consumers must also set a
 job-level `timeout-minutes`, because CoreSimulator commands have no portable
 macOS command-level timeout. The requested runtime major must match the built
 app's normalized `DTSDKName` major.
+
+The failure log contains the tested app's own unified-log output. Consumers
+should use short artifact retention and must not exercise fixtures that emit
+real customer profiles, device tokens, or other sensitive data.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ Store compatibility.
 
 The action terminates and uninstalls the app after the smoke test. On failure,
 launch and survival failures write simulator diagnostics to its `log-path`
-output. Consumers should add an `if: failure()` artifact-upload step when that
+output. The `failure-reason` output distinguishes invalid inputs and products,
+SDK/runtime mismatch, runtime selection or boot failure, install failure,
+launch rejection, failure to survive, and unexpected command failure. Outputs
+that could not yet be determined use `unknown`; a failure before the log is
+initialized can leave other outputs unset. Consumers should add an `if: failure()` artifact-upload step when that
 output is non-empty; the action intentionally does not replay app-controlled
 simulator logs through the GitHub command parser. Consumers must also set a
 job-level `timeout-minutes`, because CoreSimulator commands have no portable

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Store compatibility.
 
 The action terminates and uninstalls the app after the smoke test. On failure,
 launch and survival failures write simulator diagnostics to the explicit
-`log-path` input. The `failure-reason` output distinguishes invalid inputs and products,
-SDK/runtime mismatch, runtime selection or boot failure, install failure,
-launch rejection, failure to survive, and unexpected command failure. Outputs
+`log-path` input. The `failure-reason` output is one of `invalid-input`, `invalid-app`,
+`sdk-mismatch`, `runtime-unavailable`, `runtime-selection-failed`,
+`simulator-boot-failed`, `install-failed`, `launch-failed`, `did-not-survive`,
+`unexpected-error`, or `none` after success. Outputs
 that could not yet be determined use `unknown`. Consumers should pass a known
 `log-path`, then add an `if: failure()` artifact-upload step for that same path
 with `if-no-files-found: ignore`. A failed composite action is not required to

--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ This repository centralizes **GitHub Actions, workflows, Fastlane lanes, and aut
 does not remain alive for the configured survival window. It is a launch-crash
 sentinel, not evidence of lifecycle callbacks, push delivery, signing, or App
 Store compatibility.
+
+The action terminates and uninstalls the app after the smoke test. On failure,
+launch and survival failures write simulator diagnostics to its `log-path`
+output. Consumers should add an `if: failure()` artifact-upload step when that
+output is non-empty; the action intentionally does not replay app-controlled
+simulator logs through the GitHub command parser. Consumers must also set a
+job-level `timeout-minutes`, because CoreSimulator commands have no portable
+macOS command-level timeout. The requested runtime major must match the built
+app's normalized `DTSDKName` major.

--- a/github-actions/ios/launch-simulator-app/v1/action.yml
+++ b/github-actions/ios/launch-simulator-app/v1/action.yml
@@ -1,0 +1,57 @@
+name: Launch iOS simulator app
+description: Install a built .app on an available simulator, launch it, and fail if the process exits during the survival window.
+
+inputs:
+  app-path:
+    description: Absolute or workspace-relative path to the built simulator .app.
+    required: true
+  expected-ios-major:
+    description: Required simulator runtime major version, for example 27.
+    required: true
+  survival-seconds:
+    description: Whole seconds the launched process must remain alive.
+    required: false
+    default: '5'
+  log-path:
+    description: Path for launch metadata and failure logs. Defaults under RUNNER_TEMP.
+    required: false
+    default: ''
+
+outputs:
+  bundle-id:
+    description: Bundle identifier read from the built app.
+    value: ${{ steps.launch.outputs.bundle-id }}
+  launched-pid:
+    description: PID returned by simctl launch.
+    value: ${{ steps.launch.outputs.launched-pid }}
+  simulator-udid:
+    description: Simulator used for the launch smoke test.
+    value: ${{ steps.launch.outputs.simulator-udid }}
+  simulator-runtime:
+    description: Simulator runtime identifier used for the launch smoke test.
+    value: ${{ steps.launch.outputs.simulator-runtime }}
+  app-sdk-name:
+    description: DTSDKName embedded in the built app.
+    value: ${{ steps.launch.outputs.app-sdk-name }}
+  app-sdk-major:
+    description: Major iOS simulator SDK embedded in the built app.
+    value: ${{ steps.launch.outputs.app-sdk-major }}
+  classification:
+    description: launch-passed or launch-failed.
+    value: ${{ steps.launch.outputs.classification }}
+  log-path:
+    description: Launch metadata and failure log path.
+    value: ${{ steps.launch.outputs.log-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install, launch, and verify process survival
+      id: launch
+      shell: bash
+      env:
+        APP_PATH: ${{ inputs.app-path }}
+        EXPECTED_IOS_MAJOR: ${{ inputs.expected-ios-major }}
+        SURVIVAL_SECONDS: ${{ inputs.survival-seconds }}
+        LAUNCH_LOG_PATH: ${{ inputs.log-path }}
+      run: bash "$GITHUB_ACTION_PATH/launch.sh"

--- a/github-actions/ios/launch-simulator-app/v1/action.yml
+++ b/github-actions/ios/launch-simulator-app/v1/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Absolute or workspace-relative path to the built simulator .app.
     required: true
   expected-ios-major:
-    description: Positive simulator runtime major version, for example 27. It must also match the app's DTSDKName major version.
+    description: Positive simulator runtime major version, for example 27. The app must be rebuilt with the same DTSDKName major version.
     required: true
   survival-seconds:
     description: Whole seconds from 1 through 120 that the launched process must remain alive.
@@ -19,26 +19,29 @@ inputs:
 
 outputs:
   bundle-id:
-    description: Bundle identifier read from the built app.
+    description: Bundle identifier read from the built app, or unknown when it could not be determined.
     value: ${{ steps.launch.outputs.bundle-id }}
   launched-pid:
     description: PID returned by simctl launch.
     value: ${{ steps.launch.outputs.launched-pid }}
   simulator-udid:
-    description: Simulator used for the launch smoke test.
+    description: Simulator used for the launch smoke test, or unknown before selection.
     value: ${{ steps.launch.outputs.simulator-udid }}
   simulator-runtime:
-    description: Simulator runtime identifier used for the launch smoke test.
+    description: Simulator runtime identifier used for the launch smoke test, or unknown before selection.
     value: ${{ steps.launch.outputs.simulator-runtime }}
   app-sdk-name:
-    description: DTSDKName embedded in the built app.
+    description: DTSDKName embedded in the built app, or unknown when unreadable.
     value: ${{ steps.launch.outputs.app-sdk-name }}
   app-sdk-major:
-    description: Major iOS simulator SDK embedded in the built app.
+    description: Major iOS simulator SDK embedded in the built app, or unknown when unreadable.
     value: ${{ steps.launch.outputs.app-sdk-major }}
   classification:
     description: launch-passed or launch-failed.
     value: ${{ steps.launch.outputs.classification }}
+  failure-reason:
+    description: Machine-readable failure category, or none after a successful launch.
+    value: ${{ steps.launch.outputs.failure-reason }}
   log-path:
     description: Launch metadata and failure log path.
     value: ${{ steps.launch.outputs.log-path }}

--- a/github-actions/ios/launch-simulator-app/v1/action.yml
+++ b/github-actions/ios/launch-simulator-app/v1/action.yml
@@ -11,7 +11,7 @@ inputs:
   survival-seconds:
     description: Whole seconds from 1 through 120 that the launched process must remain alive.
     required: false
-    default: '5'
+    default: '10'
   log-path:
     description: Path for launch metadata and failure logs. Defaults under RUNNER_TEMP.
     required: false
@@ -22,7 +22,7 @@ outputs:
     description: Bundle identifier read from the built app, or unknown when it could not be determined.
     value: ${{ steps.launch.outputs.bundle-id }}
   launched-pid:
-    description: PID returned by simctl launch.
+    description: PID returned by simctl launch, or unknown before launch.
     value: ${{ steps.launch.outputs.launched-pid }}
   simulator-udid:
     description: Simulator used for the launch smoke test, or unknown before selection.

--- a/github-actions/ios/launch-simulator-app/v1/action.yml
+++ b/github-actions/ios/launch-simulator-app/v1/action.yml
@@ -43,7 +43,7 @@ outputs:
     description: Machine-readable failure category, or none after a successful launch.
     value: ${{ steps.launch.outputs.failure-reason }}
   log-path:
-    description: Launch metadata and failure log path.
+    description: Launch metadata and failure log path, or unknown when the requested path was rejected.
     value: ${{ steps.launch.outputs.log-path }}
 
 runs:

--- a/github-actions/ios/launch-simulator-app/v1/action.yml
+++ b/github-actions/ios/launch-simulator-app/v1/action.yml
@@ -1,15 +1,15 @@
 name: Launch iOS simulator app
-description: Install a built .app on an available simulator, launch it, and fail if the process exits during the survival window.
+description: Install a simulator .app, launch it, and fail if its process exits or changes simulator identity during the survival window. The app is terminated and uninstalled afterward. Requires a macOS runner with xcrun, PlistBuddy, ps, and Python 3.
 
 inputs:
   app-path:
     description: Absolute or workspace-relative path to the built simulator .app.
     required: true
   expected-ios-major:
-    description: Required simulator runtime major version, for example 27.
+    description: Positive simulator runtime major version, for example 27. It must also match the app's DTSDKName major version.
     required: true
   survival-seconds:
-    description: Whole seconds the launched process must remain alive.
+    description: Whole seconds from 1 through 120 that the launched process must remain alive.
     required: false
     default: '5'
   log-path:

--- a/github-actions/ios/launch-simulator-app/v1/action.yml
+++ b/github-actions/ios/launch-simulator-app/v1/action.yml
@@ -60,9 +60,9 @@ runs:
         EXPECTED_IOS_MAJOR: ${{ inputs.expected-ios-major }}
         SURVIVAL_SECONDS: ${{ inputs.survival-seconds }}
         LAUNCH_LOG_PATH: ${{ inputs.log-path }}
-        XCRUN_BIN: xcrun
-        PYTHON_BIN: python3
+        XCRUN_BIN: /usr/bin/xcrun
+        PYTHON_BIN: /usr/bin/python3
         PLIST_BUDDY_BIN: /usr/libexec/PlistBuddy
-        PS_BIN: ps
-        SLEEP_BIN: sleep
+        PS_BIN: /bin/ps
+        SLEEP_BIN: /bin/sleep
       run: bash "$GITHUB_ACTION_PATH/launch.sh"

--- a/github-actions/ios/launch-simulator-app/v1/action.yml
+++ b/github-actions/ios/launch-simulator-app/v1/action.yml
@@ -40,7 +40,10 @@ outputs:
     description: launch-passed or launch-failed.
     value: ${{ steps.launch.outputs.classification }}
   failure-reason:
-    description: Machine-readable failure category, or none after a successful launch.
+    description: >-
+      One of invalid-input, invalid-app, sdk-mismatch, runtime-unavailable,
+      runtime-selection-failed, simulator-boot-failed, install-failed, launch-failed,
+      did-not-survive, unexpected-error, or none after a successful launch.
     value: ${{ steps.launch.outputs.failure-reason }}
   log-path:
     description: Launch metadata and failure log path, or unknown when the requested path was rejected.

--- a/github-actions/ios/launch-simulator-app/v1/action.yml
+++ b/github-actions/ios/launch-simulator-app/v1/action.yml
@@ -60,4 +60,9 @@ runs:
         EXPECTED_IOS_MAJOR: ${{ inputs.expected-ios-major }}
         SURVIVAL_SECONDS: ${{ inputs.survival-seconds }}
         LAUNCH_LOG_PATH: ${{ inputs.log-path }}
+        XCRUN_BIN: xcrun
+        PYTHON_BIN: python3
+        PLIST_BUDDY_BIN: /usr/libexec/PlistBuddy
+        PS_BIN: ps
+        SLEEP_BIN: sleep
       run: bash "$GITHUB_ACTION_PATH/launch.sh"

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -10,7 +10,7 @@ sleep_bin="${SLEEP_BIN:-sleep}"
 
 app_path="${APP_PATH:-}"
 expected_ios_major="${EXPECTED_IOS_MAJOR:-}"
-survival_seconds="${SURVIVAL_SECONDS:-5}"
+survival_seconds="${SURVIVAL_SECONDS:-10}"
 log_path="${LAUNCH_LOG_PATH:-${RUNNER_TEMP:-/tmp}/ios-simulator-launch-${BASHPID:-$$}.log}"
 bundle_id=unknown
 executable=unknown
@@ -19,7 +19,7 @@ app_sdk_major=unknown
 simulator_udid=unknown
 simulator_runtime=unknown
 initial_state=unknown
-launched_pid=
+launched_pid=unknown
 booted_by_script=false
 installed=false
 failure_recorded=false

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -29,6 +29,12 @@ early_failure() {
   echo "::error title=iOS simulator launch smoke::$message"
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     {
+      echo "bundle-id=$bundle_id"
+      echo "launched-pid=$launched_pid"
+      echo "simulator-udid=$simulator_udid"
+      echo "simulator-runtime=$simulator_runtime"
+      echo "app-sdk-name=$sdk_name"
+      echo "app-sdk-major=$app_sdk_major"
       echo 'classification=launch-failed'
       echo 'failure-reason=invalid-input'
       echo 'log-path='
@@ -194,7 +200,7 @@ for runtime, devices in payload.get("devices", {}).items():
         state = device.get("state", "Shutdown")
         if state not in ("Booted", "Shutdown"):
             continue
-        candidates.append((major, minor, state == "Booted", device["udid"], state, runtime))
+        candidates.append((state == "Booted", major, minor, device["udid"], state, runtime))
 
 if not candidates:
     sys.exit("No available iPhone simulator matches the requested iOS runtime.")
@@ -264,9 +270,22 @@ for devices in payload.get("devices", {}).values():
             print(device.get("state", "unknown"))
             raise SystemExit(0)
 raise SystemExit(1)
-' "$simulator_udid" 2>> "$log_path")" && [[ "$current_state" == "Booted" ]]; then
-      bootstatus_boot_if_needed=false
+' "$simulator_udid" 2>> "$log_path")"; then
+      if [[ "$current_state" == "Shutdown" ]]; then
+        booted_by_script=true
+      else
+        # Another owner has already advanced this simulator out of Shutdown.
+        # Wait for it without later shutting down state that we do not own.
+        bootstatus_boot_if_needed=false
+      fi
     else
+      # State could not be re-read, so fail closed on ownership. bootstatus
+      # without -b may still observe another owner's in-flight boot, but this
+      # action will never shut that simulator down.
+      bootstatus_boot_if_needed=false
+      booted_by_script=false
+    fi
+    if [[ "$bootstatus_boot_if_needed" == true ]]; then
       booted_by_script=true
     fi
   fi
@@ -301,8 +320,14 @@ for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
   "$sleep_bin" 1
   # BSD ps returns the full executable path for comm=. Bind that path to the
   # selected simulator and reject a crashed process waiting to be reaped.
-  if ! process_status="$("$ps_bin" -ww -p "$launched_pid" -o state= -o comm= 2>/dev/null)"; then
+  if process_status="$("$ps_bin" -ww -p "$launched_pid" -o state= -o comm= 2>/dev/null)"; then
+    process_status_code=0
+  else
+    process_status_code="$?"
     process_status=
+  fi
+  if (( process_status_code > 1 )); then
+    fail unexpected-error "Could not inspect the launched process after ${elapsed}s."
   fi
   read -r process_state process_command <<< "$process_status" || true
   if [[ -z "$process_status" \

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -347,7 +347,7 @@ for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
   fi
   read -r process_state process_command <<< "$process_status" || true
   if [[ -z "$process_status" \
-    || "$process_state" != [RSI]* \
+    || "$process_state" != [RSIU]* \
     || "${process_command##*/}" != "$executable" \
     || "$process_command" != *"/Devices/$simulator_udid/"* ]]; then
     printf 'ps observation after %ss: %s\n' \

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -169,7 +169,7 @@ executable="$raw_executable"
 if ! raw_sdk_name="$("$plist_buddy_bin" -c 'Print :DTSDKName' "$app_path/Info.plist" 2>&1)"; then
   fail invalid-app "The built app has no readable DTSDKName: $raw_sdk_name"
 fi
-if [[ ! "$raw_sdk_name" =~ ^iphonesimulator([0-9]+)(\.[0-9]+)?$ ]]; then
+if [[ ! "$raw_sdk_name" =~ ^iphonesimulator([0-9]+)(\.[0-9]+)*$ ]]; then
   fail invalid-app 'The built app is not an iPhone simulator product.'
 fi
 app_sdk_major="$((10#${BASH_REMATCH[1]}))"
@@ -284,9 +284,6 @@ raise SystemExit(1)
       # action will never shut that simulator down.
       bootstatus_boot_if_needed=false
       booted_by_script=false
-    fi
-    if [[ "$bootstatus_boot_if_needed" == true ]]; then
-      booted_by_script=true
     fi
   fi
 fi

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -22,6 +22,7 @@ initial_state=unknown
 launched_pid=
 booted_by_script=false
 installed=false
+failure_recorded=false
 
 early_failure() {
   local message="$1"
@@ -29,6 +30,7 @@ early_failure() {
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     {
       echo 'classification=launch-failed'
+      echo 'failure-reason=invalid-input'
       echo 'log-path='
     } >> "$GITHUB_OUTPUT"
   fi
@@ -58,7 +60,8 @@ github_command_value() {
 }
 
 record_failure() {
-  local message="$1"
+  local reason="$1"
+  local message="$2"
   local safe_message
   local annotation_message
   local safe_bundle_id
@@ -68,6 +71,7 @@ record_failure() {
   local safe_sdk_name
   local safe_app_sdk_major
   local safe_log_path
+  failure_recorded=true
   safe_message="$(single_line "$message")"
   annotation_message="$(github_command_value "$message")"
   safe_bundle_id="$(single_line "$bundle_id")"
@@ -90,6 +94,7 @@ record_failure() {
       echo "app-sdk-name=$safe_sdk_name"
       echo "app-sdk-major=$safe_app_sdk_major"
       echo 'classification=launch-failed'
+      echo "failure-reason=$reason"
       echo "log-path=$safe_log_path"
     } >> "$GITHUB_OUTPUT"
   fi
@@ -98,6 +103,7 @@ record_failure() {
       echo '## iOS simulator launch smoke'
       echo
       echo '**Classification:** launch-failed'
+      echo "**Failure category:** $reason"
       echo "**Reason:** $safe_message"
       echo "**App SDK:** \`$safe_sdk_name\`"
       echo "**Runtime:** \`$safe_simulator_runtime\`"
@@ -107,53 +113,63 @@ record_failure() {
 }
 
 fail() {
-  record_failure "$1"
+  record_failure "$1" "$2"
   exit 1
 }
 
+unexpected_failure() {
+  local status="$?"
+  trap - ERR
+  if [[ "$failure_recorded" != true ]]; then
+    record_failure unexpected-error "An unexpected command failed while running the launch smoke test."
+  fi
+  exit "$status"
+}
+trap unexpected_failure ERR
+
 if [[ -z "$app_path" ]]; then
-  fail 'APP_PATH is required.'
+  fail invalid-input 'APP_PATH is required.'
 fi
 if [[ ! -d "$app_path" || ! -f "$app_path/Info.plist" ]]; then
-  fail "Built simulator app is missing or has no Info.plist: $app_path"
+  fail invalid-input "Built simulator app is missing or has no Info.plist: $app_path"
 fi
 if [[ ! "$expected_ios_major" =~ ^[1-9][0-9]*$ ]]; then
-  fail 'EXPECTED_IOS_MAJOR must be a positive whole number.'
+  fail invalid-input 'EXPECTED_IOS_MAJOR must be a positive whole number.'
 fi
 survival_pattern='^([1-9]|[1-9][0-9]|1[01][0-9]|120)$'
 if [[ ! "$survival_seconds" =~ $survival_pattern ]]; then
-  fail 'SURVIVAL_SECONDS must be a whole number from 1 through 120.'
+  fail invalid-input 'SURVIVAL_SECONDS must be a whole number from 1 through 120.'
 fi
 
 if ! raw_bundle_id="$("$plist_buddy_bin" -c 'Print :CFBundleIdentifier' "$app_path/Info.plist" 2>&1)"; then
-  fail "The built app has no readable CFBundleIdentifier: $raw_bundle_id"
+  fail invalid-app "The built app has no readable CFBundleIdentifier: $raw_bundle_id"
 fi
 if [[ ! "$raw_bundle_id" =~ ^[A-Za-z0-9.-]+$ ]]; then
-  fail 'The built app has an invalid CFBundleIdentifier.'
+  fail invalid-app 'The built app has an invalid CFBundleIdentifier.'
 fi
 bundle_id="$raw_bundle_id"
 
 if ! raw_executable="$("$plist_buddy_bin" -c 'Print :CFBundleExecutable' "$app_path/Info.plist" 2>&1)"; then
-  fail "The built app has no readable CFBundleExecutable: $raw_executable"
+  fail invalid-app "The built app has no readable CFBundleExecutable: $raw_executable"
 fi
 # Spaces are valid in an executable name. Restrict the remaining shape so the
 # value cannot inject GitHub outputs or an NSPredicate used for failure logs.
 executable_pattern='^[-A-Za-z0-9._ ]+$'
 if [[ ! "$raw_executable" =~ $executable_pattern ]]; then
-  fail 'The built app has an invalid CFBundleExecutable.'
+  fail invalid-app 'The built app has an invalid CFBundleExecutable.'
 fi
 executable="$raw_executable"
 
 if ! raw_sdk_name="$("$plist_buddy_bin" -c 'Print :DTSDKName' "$app_path/Info.plist" 2>&1)"; then
-  fail "The built app has no readable DTSDKName: $raw_sdk_name"
+  fail invalid-app "The built app has no readable DTSDKName: $raw_sdk_name"
 fi
 if [[ ! "$raw_sdk_name" =~ ^iphonesimulator([0-9]+)(\.[0-9]+)?$ ]]; then
-  fail 'The built app is not an iPhone simulator product.'
+  fail invalid-app 'The built app is not an iPhone simulator product.'
 fi
 app_sdk_major="$((10#${BASH_REMATCH[1]}))"
 sdk_name="$raw_sdk_name"
 if (( expected_ios_major != app_sdk_major )); then
-  fail "The app SDK $sdk_name does not match the requested iOS $expected_ios_major validation runtime."
+  fail sdk-mismatch "The app SDK $sdk_name does not match the requested iOS $expected_ios_major validation runtime."
 fi
 
 if ! selection="$("$xcrun_bin" simctl list devices available --json 2>> "$log_path" | "$python_bin" -c '
@@ -186,7 +202,7 @@ candidates.sort(reverse=True)
 _, _, _, udid, state, runtime = candidates[0]
 print(f"{udid}\t{state}\t{runtime}")
 ' "$expected_ios_major" 2>> "$log_path")"; then
-  fail "Could not select an iPhone simulator for iOS $expected_ios_major."
+  fail runtime-unavailable "Could not select an iPhone simulator for iOS $expected_ios_major."
 fi
 
 IFS=$'\t' read -r simulator_udid initial_state simulator_runtime <<< "$selection"
@@ -194,7 +210,7 @@ if [[ "$selection" == *$'\n'* \
   || ! "$simulator_udid" =~ ^[A-Za-z0-9-]+$ \
   || -z "$initial_state" \
   || ! "$simulator_runtime" =~ ^com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9-]+$ ]]; then
-  fail 'Could not parse a single simulator identity from device selection.'
+  fail runtime-selection-failed 'Could not parse a single simulator identity from device selection.'
 fi
 
 collect_failure_log() {
@@ -228,13 +244,31 @@ trap 'exit 143' TERM
 
 bootstatus_boot_if_needed=false
 if [[ "$initial_state" == "Shutdown" ]]; then
-  booted_by_script=true
   bootstatus_boot_if_needed=true
-  if ! boot_output="$("$xcrun_bin" simctl boot "$simulator_udid" 2>&1)"; then
+  if boot_output="$("$xcrun_bin" simctl boot "$simulator_udid" 2>&1)"; then
+    booted_by_script=true
+  else
     # A device observed while transitioning can reject a duplicate boot. Let
-    # bootstatus be the authoritative workflow-level readiness check; callers
-    # retain the enclosing job timeout as the upper bound.
+    # bootstatus be the authoritative readiness check. Re-read state first so
+    # cleanup never shuts down a simulator another process booted in the race.
     printf 'simctl boot returned: %s\n' "$boot_output" >> "$log_path"
+    if current_state="$("$xcrun_bin" simctl list devices available --json 2>> "$log_path" | "$python_bin" -c '
+import json
+import sys
+
+udid = sys.argv[1]
+payload = json.load(sys.stdin)
+for devices in payload.get("devices", {}).values():
+    for device in devices:
+        if device.get("udid") == udid:
+            print(device.get("state", "unknown"))
+            raise SystemExit(0)
+raise SystemExit(1)
+' "$simulator_udid" 2>> "$log_path")" && [[ "$current_state" == "Booted" ]]; then
+      bootstatus_boot_if_needed=false
+    else
+      booted_by_script=true
+    fi
   fi
 fi
 bootstatus_arguments=(simctl bootstatus "$simulator_udid")
@@ -242,15 +276,15 @@ if [[ "$bootstatus_boot_if_needed" == true ]]; then
   bootstatus_arguments+=(-b)
 fi
 if ! bootstatus_output="$("$xcrun_bin" "${bootstatus_arguments[@]}" 2>&1)"; then
-  fail "Simulator $simulator_udid did not finish booting: $bootstatus_output"
+  fail simulator-boot-failed "Simulator $simulator_udid did not finish booting: $bootstatus_output"
 fi
 if ! install_output="$("$xcrun_bin" simctl install "$simulator_udid" "$app_path" 2>&1)"; then
-  fail "Could not install $bundle_id on simulator $simulator_udid: $install_output"
+  fail install-failed "Could not install $bundle_id on simulator $simulator_udid: $install_output"
 fi
 installed=true
 
 if ! launch_output="$("$xcrun_bin" simctl launch --terminate-running-process "$simulator_udid" "$bundle_id" 2>&1)"; then
-  record_failure "simctl could not launch $bundle_id: $launch_output"
+  record_failure launch-failed "simctl could not launch $bundle_id: $launch_output"
   collect_failure_log
   exit 1
 fi
@@ -258,7 +292,7 @@ printf '%s\n' "$launch_output" >> "$log_path"
 escaped_bundle_id="${bundle_id//./\\.}"
 launched_pid="$(printf '%s\n' "$launch_output" | sed -nE "s/^${escaped_bundle_id}: ([1-9][0-9]*)$/\\1/p" | tail -1)"
 if [[ -z "$launched_pid" ]]; then
-  record_failure "simctl launch did not return a PID for $bundle_id."
+  record_failure launch-failed "simctl launch did not return a PID for $bundle_id."
   collect_failure_log
   exit 1
 fi
@@ -275,7 +309,7 @@ for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
     || "$process_state" == Z* \
     || "${process_command##*/}" != "$executable" \
     || "$process_command" != *"/Devices/$simulator_udid/"* ]]; then
-    record_failure "$bundle_id exited or changed identity after ${elapsed}s of the ${survival_seconds}s survival window."
+    record_failure did-not-survive "$bundle_id exited or changed identity after ${elapsed}s of the ${survival_seconds}s survival window."
     collect_failure_log
     exit 1
   fi
@@ -300,6 +334,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "app-sdk-name=$sdk_name"
     echo "app-sdk-major=$app_sdk_major"
     echo 'classification=launch-passed'
+    echo 'failure-reason=none'
     echo "log-path=$log_path"
   } >> "$GITHUB_OUTPUT"
 fi

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -61,6 +61,9 @@ early_failure() {
 }
 
 if [[ "$log_path" == *$'\r'* || "$log_path" == *$'\n'* ]]; then
+  if [[ -z "$requested_log_path" ]]; then
+    early_failure 'The default launch log path must be a single-line path.' unexpected-error
+  fi
   early_failure 'LAUNCH_LOG_PATH must be a single-line path.'
 fi
 if ! mkdir -p "$(dirname "$log_path")" || ! : > "$log_path"; then
@@ -393,8 +396,10 @@ for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
   fi
   read -r process_state process_command <<< "$process_status" || true
   if (( process_status_code == 0 )) \
-    && [[ -n "$process_status" ]] \
-    && { [[ ! "$process_state" =~ ^[A-Z][A-Za-z+\<\>]*$ ]] || [[ "$process_command" != /* ]]; }; then
+    && { [[ -z "$process_status" ]] \
+    || [[ "$process_status" == *$'\n'* ]] \
+    || [[ ! "$process_state" =~ ^[A-Z][A-Za-z+\<\>]*$ ]] \
+    || [[ "$process_command" != /* ]]; }; then
     record_failure unexpected-error \
       "Could not parse the process inspection result after ${elapsed}s: $(single_line "$process_status")"
     collect_failure_log

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -171,6 +171,9 @@ trap unexpected_failure ERR
 if [[ -z "$app_path" ]]; then
   fail invalid-input 'APP_PATH is required.'
 fi
+if [[ "$app_path" == -* ]]; then
+  fail invalid-input 'APP_PATH must not be option-shaped.'
+fi
 if [[ ! -d "$app_path" || ! -f "$app_path/Info.plist" ]]; then
   fail invalid-input "Built simulator app is missing or has no Info.plist: $app_path"
 fi

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -294,11 +294,12 @@ raise SystemExit(1)
         bootstatus_boot_if_needed=false
       fi
     else
-      # State could not be re-read, so fail closed on ownership. bootstatus
-      # without -b may still observe another owner's in-flight boot, but this
-      # action will never shut that simulator down.
-      bootstatus_boot_if_needed=false
+      # State could not be re-read, so ownership cannot be established and
+      # nothing in this job will boot the device. Fail rather than waiting on
+      # a boot that may never happen.
       booted_by_script=false
+      fail simulator-boot-failed \
+        "Simulator $simulator_udid rejected boot and its state could not be re-read: $boot_output"
     fi
   fi
 fi
@@ -346,6 +347,9 @@ for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
     || "$process_state" == Z* \
     || "${process_command##*/}" != "$executable" \
     || "$process_command" != *"/Devices/$simulator_udid/"* ]]; then
+    printf 'ps observation after %ss: %s\n' \
+      "$elapsed" \
+      "$(single_line "$process_status")" >> "$log_path"
     record_failure did-not-survive "$bundle_id exited or changed identity after ${elapsed}s of the ${survival_seconds}s survival window."
     collect_failure_log
     exit 1

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -281,14 +281,18 @@ collect_failure_log() {
     app_log="$("$xcrun_bin" simctl spawn "$simulator_udid" log show \
       --last "${diagnostic_window_seconds}s" \
       --style compact \
-      --predicate "process == '$executable'" 2>/dev/null || true)"
+      --predicate "process == '$executable'" 2>/dev/null \
+      | /usr/bin/tail -n 2000 \
+      | /usr/bin/head -c 1048576 || true)"
     [[ -z "$app_log" ]] || break
     "$sleep_bin" 1
   done
   simulator_log="$("$xcrun_bin" simctl spawn "$simulator_udid" log show \
     --last "${diagnostic_window_seconds}s" \
     --style compact \
-    --predicate "process == '$executable' OR process == 'SpringBoard' OR process == 'ReportCrash' OR process == 'launchd_sim'" 2>&1 || true)"
+    --predicate "process == '$executable' OR process == 'SpringBoard' OR process == 'ReportCrash' OR process == 'launchd_sim'" 2>&1 \
+    | /usr/bin/tail -n 2000 \
+    | /usr/bin/head -c 1048576 || true)"
   failure_log="
 ===== App log for $executable =====
 $app_log

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -344,13 +344,13 @@ for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
   fi
   read -r process_state process_command <<< "$process_status" || true
   if [[ -z "$process_status" \
-    || "$process_state" == Z* \
+    || "$process_state" != [RSI]* \
     || "${process_command##*/}" != "$executable" \
     || "$process_command" != *"/Devices/$simulator_udid/"* ]]; then
     printf 'ps observation after %ss: %s\n' \
       "$elapsed" \
       "$(single_line "$process_status")" >> "$log_path"
-    record_failure did-not-survive "$bundle_id exited or changed identity after ${elapsed}s of the ${survival_seconds}s survival window."
+    record_failure did-not-survive "$bundle_id exited, became non-runnable, or changed identity after ${elapsed}s of the ${survival_seconds}s survival window."
     collect_failure_log
     exit 1
   fi

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -110,7 +110,9 @@ record_failure() {
       echo
       echo '**Classification:** launch-failed'
       echo "**Failure category:** $reason"
-      echo "**Reason:** $safe_message"
+      echo '**Reason:**'
+      echo
+      echo "    $safe_message"
       echo "**App SDK:** \`$safe_sdk_name\`"
       echo "**Runtime:** \`$safe_simulator_runtime\`"
       echo "**Failure log:** \`$safe_log_path\`"
@@ -160,7 +162,7 @@ if ! raw_executable="$("$plist_buddy_bin" -c 'Print :CFBundleExecutable' "$app_p
 fi
 # Spaces are valid in an executable name. Restrict the remaining shape so the
 # value cannot inject GitHub outputs or an NSPredicate used for failure logs.
-executable_pattern='^[-A-Za-z0-9._ ]+$'
+executable_pattern='^[-A-Za-z0-9._]+([ ]+[-A-Za-z0-9._]+)*$'
 if [[ ! "$raw_executable" =~ $executable_pattern ]]; then
   fail invalid-app 'The built app has an invalid CFBundleExecutable.'
 fi

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -8,10 +8,10 @@ plist_buddy_bin="${PLIST_BUDDY_BIN:-/usr/libexec/PlistBuddy}"
 ps_bin="${PS_BIN:-ps}"
 sleep_bin="${SLEEP_BIN:-sleep}"
 
-app_path="${APP_PATH:?APP_PATH is required}"
+app_path="${APP_PATH:-}"
 expected_ios_major="${EXPECTED_IOS_MAJOR:-}"
 survival_seconds="${SURVIVAL_SECONDS:-5}"
-log_path="${LAUNCH_LOG_PATH:-${RUNNER_TEMP:-/tmp}/ios-simulator-launch.log}"
+log_path="${LAUNCH_LOG_PATH:-${RUNNER_TEMP:-/tmp}/ios-simulator-launch-${BASHPID:-$$}.log}"
 bundle_id=unknown
 executable=unknown
 sdk_name=unknown
@@ -23,23 +23,74 @@ launched_pid=
 booted_by_script=false
 installed=false
 
-mkdir -p "$(dirname "$log_path")"
-: > "$log_path"
-
-record_failure() {
+early_failure() {
   local message="$1"
-  echo "$message" | tee -a "$log_path" >&2
   echo "::error title=iOS simulator launch smoke::$message"
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     {
-      echo "bundle-id=$bundle_id"
-      echo "launched-pid=$launched_pid"
-      echo "simulator-udid=$simulator_udid"
-      echo "simulator-runtime=$simulator_runtime"
-      echo "app-sdk-name=$sdk_name"
-      echo "app-sdk-major=$app_sdk_major"
       echo 'classification=launch-failed'
-      echo "log-path=$log_path"
+      echo 'log-path='
+    } >> "$GITHUB_OUTPUT"
+  fi
+  exit 1
+}
+
+if [[ "$log_path" == *$'\r'* || "$log_path" == *$'\n'* ]]; then
+  early_failure 'LAUNCH_LOG_PATH must be a single-line path.'
+fi
+if ! mkdir -p "$(dirname "$log_path")" || ! : > "$log_path"; then
+  early_failure 'LAUNCH_LOG_PATH could not be created.'
+fi
+
+single_line() {
+  local value="$1"
+  value="${value//$'\r'/ }"
+  value="${value//$'\n'/ }"
+  printf '%s' "$value"
+}
+
+github_command_value() {
+  local value="$1"
+  value="${value//'%'/'%25'}"
+  value="${value//$'\r'/'%0D'}"
+  value="${value//$'\n'/'%0A'}"
+  printf '%s' "$value"
+}
+
+record_failure() {
+  local message="$1"
+  local safe_message
+  local annotation_message
+  local safe_bundle_id
+  local safe_launched_pid
+  local safe_simulator_udid
+  local safe_simulator_runtime
+  local safe_sdk_name
+  local safe_app_sdk_major
+  local safe_log_path
+  safe_message="$(single_line "$message")"
+  annotation_message="$(github_command_value "$message")"
+  safe_bundle_id="$(single_line "$bundle_id")"
+  safe_launched_pid="$(single_line "$launched_pid")"
+  safe_simulator_udid="$(single_line "$simulator_udid")"
+  safe_simulator_runtime="$(single_line "$simulator_runtime")"
+  safe_sdk_name="$(single_line "$sdk_name")"
+  safe_app_sdk_major="$(single_line "$app_sdk_major")"
+  safe_log_path="$(single_line "$log_path")"
+
+  printf '%s\n' "$message" >> "$log_path"
+  printf 'iOS simulator launch smoke failed: %s\n' "$safe_message" >&2
+  echo "::error title=iOS simulator launch smoke::$annotation_message"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "bundle-id=$safe_bundle_id"
+      echo "launched-pid=$safe_launched_pid"
+      echo "simulator-udid=$safe_simulator_udid"
+      echo "simulator-runtime=$safe_simulator_runtime"
+      echo "app-sdk-name=$safe_sdk_name"
+      echo "app-sdk-major=$safe_app_sdk_major"
+      echo 'classification=launch-failed'
+      echo "log-path=$safe_log_path"
     } >> "$GITHUB_OUTPUT"
   fi
   if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
@@ -47,10 +98,10 @@ record_failure() {
       echo '## iOS simulator launch smoke'
       echo
       echo '**Classification:** launch-failed'
-      echo "**Reason:** $message"
-      echo "**App SDK:** \`$sdk_name\`"
-      echo "**Runtime:** \`$simulator_runtime\`"
-      echo "**Failure log:** \`$log_path\`"
+      echo "**Reason:** $safe_message"
+      echo "**App SDK:** \`$safe_sdk_name\`"
+      echo "**Runtime:** \`$safe_simulator_runtime\`"
+      echo "**Failure log:** \`$safe_log_path\`"
     } >> "$GITHUB_STEP_SUMMARY"
   fi
 }
@@ -60,31 +111,52 @@ fail() {
   exit 1
 }
 
+if [[ -z "$app_path" ]]; then
+  fail 'APP_PATH is required.'
+fi
 if [[ ! -d "$app_path" || ! -f "$app_path/Info.plist" ]]; then
   fail "Built simulator app is missing or has no Info.plist: $app_path"
 fi
-if [[ ! "$expected_ios_major" =~ ^[0-9]+$ ]]; then
-  fail 'EXPECTED_IOS_MAJOR must be a whole number.'
+if [[ ! "$expected_ios_major" =~ ^[1-9][0-9]*$ ]]; then
+  fail 'EXPECTED_IOS_MAJOR must be a positive whole number.'
 fi
-if [[ ! "$survival_seconds" =~ ^[1-9][0-9]*$ ]]; then
-  fail 'SURVIVAL_SECONDS must be a positive whole number.'
+survival_pattern='^([1-9]|[1-9][0-9]|1[01][0-9]|120)$'
+if [[ ! "$survival_seconds" =~ $survival_pattern ]]; then
+  fail 'SURVIVAL_SECONDS must be a whole number from 1 through 120.'
 fi
 
-if ! bundle_id="$("$plist_buddy_bin" -c 'Print :CFBundleIdentifier' "$app_path/Info.plist" 2>&1)"; then
-  fail "The built app has no readable CFBundleIdentifier: $bundle_id"
+if ! raw_bundle_id="$("$plist_buddy_bin" -c 'Print :CFBundleIdentifier' "$app_path/Info.plist" 2>&1)"; then
+  fail "The built app has no readable CFBundleIdentifier: $raw_bundle_id"
 fi
-if ! executable="$("$plist_buddy_bin" -c 'Print :CFBundleExecutable' "$app_path/Info.plist" 2>&1)"; then
-  fail "The built app has no readable CFBundleExecutable: $executable"
+if [[ ! "$raw_bundle_id" =~ ^[A-Za-z0-9.-]+$ ]]; then
+  fail 'The built app has an invalid CFBundleIdentifier.'
 fi
-if ! sdk_name="$("$plist_buddy_bin" -c 'Print :DTSDKName' "$app_path/Info.plist" 2>&1)"; then
-  fail "The built app has no readable DTSDKName: $sdk_name"
-fi
-if [[ ! "$sdk_name" =~ ^iphonesimulator([0-9]+)(\.[0-9]+)?$ ]]; then
-  fail "The built app is not an iPhone simulator product: DTSDKName=$sdk_name"
-fi
-app_sdk_major="${BASH_REMATCH[1]}"
+bundle_id="$raw_bundle_id"
 
-if ! selection="$("$xcrun_bin" simctl list devices available --json | "$python_bin" -c '
+if ! raw_executable="$("$plist_buddy_bin" -c 'Print :CFBundleExecutable' "$app_path/Info.plist" 2>&1)"; then
+  fail "The built app has no readable CFBundleExecutable: $raw_executable"
+fi
+# Spaces are valid in an executable name. Restrict the remaining shape so the
+# value cannot inject GitHub outputs or an NSPredicate used for failure logs.
+executable_pattern='^[-A-Za-z0-9._ ]+$'
+if [[ ! "$raw_executable" =~ $executable_pattern ]]; then
+  fail 'The built app has an invalid CFBundleExecutable.'
+fi
+executable="$raw_executable"
+
+if ! raw_sdk_name="$("$plist_buddy_bin" -c 'Print :DTSDKName' "$app_path/Info.plist" 2>&1)"; then
+  fail "The built app has no readable DTSDKName: $raw_sdk_name"
+fi
+if [[ ! "$raw_sdk_name" =~ ^iphonesimulator([0-9]+)(\.[0-9]+)?$ ]]; then
+  fail 'The built app is not an iPhone simulator product.'
+fi
+app_sdk_major="$((10#${BASH_REMATCH[1]}))"
+sdk_name="$raw_sdk_name"
+if (( expected_ios_major != app_sdk_major )); then
+  fail "The app SDK $sdk_name does not match the requested iOS $expected_ios_major validation runtime."
+fi
+
+if ! selection="$("$xcrun_bin" simctl list devices available --json 2>> "$log_path" | "$python_bin" -c '
 import json
 import re
 import sys
@@ -104,6 +176,8 @@ for runtime, devices in payload.get("devices", {}).items():
         if not device.get("isAvailable", True) or "iPhone" not in device.get("name", ""):
             continue
         state = device.get("state", "Shutdown")
+        if state not in ("Booted", "Shutdown"):
+            continue
         candidates.append((major, minor, state == "Booted", device["udid"], state, runtime))
 
 if not candidates:
@@ -111,13 +185,16 @@ if not candidates:
 candidates.sort(reverse=True)
 _, _, _, udid, state, runtime = candidates[0]
 print(f"{udid}\t{state}\t{runtime}")
-' "$expected_ios_major" 2>&1)"; then
-  fail "Could not select an iPhone simulator for iOS $expected_ios_major: $selection"
+' "$expected_ios_major" 2>> "$log_path")"; then
+  fail "Could not select an iPhone simulator for iOS $expected_ios_major."
 fi
 
 IFS=$'\t' read -r simulator_udid initial_state simulator_runtime <<< "$selection"
-if (( expected_ios_major != app_sdk_major )); then
-  fail "The app SDK $sdk_name does not match the requested iOS $expected_ios_major validation runtime."
+if [[ "$selection" == *$'\n'* \
+  || ! "$simulator_udid" =~ ^[A-Za-z0-9-]+$ \
+  || -z "$initial_state" \
+  || ! "$simulator_runtime" =~ ^com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9-]+$ ]]; then
+  fail 'Could not parse a single simulator identity from device selection.'
 fi
 
 collect_failure_log() {
@@ -130,7 +207,10 @@ collect_failure_log() {
       --style compact \
       --predicate "process == '$executable'" || true
   } 2>&1)"
-  printf '%s\n' "$failure_log" | tee -a "$log_path"
+  # App-controlled log lines may look like GitHub workflow commands. Preserve
+  # them in the artifact without replaying them through the runner console.
+  printf '%s\n' "$failure_log" >> "$log_path"
+  printf 'Simulator diagnostics were written to %s.\n' "$log_path"
 }
 
 cleanup() {
@@ -146,13 +226,22 @@ trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-if [[ "$initial_state" != "Booted" ]]; then
-  if ! boot_output="$("$xcrun_bin" simctl boot "$simulator_udid" 2>&1)"; then
-    fail "Could not boot simulator $simulator_udid: $boot_output"
-  fi
+bootstatus_boot_if_needed=false
+if [[ "$initial_state" == "Shutdown" ]]; then
   booted_by_script=true
+  bootstatus_boot_if_needed=true
+  if ! boot_output="$("$xcrun_bin" simctl boot "$simulator_udid" 2>&1)"; then
+    # A device observed while transitioning can reject a duplicate boot. Let
+    # bootstatus be the authoritative workflow-level readiness check; callers
+    # retain the enclosing job timeout as the upper bound.
+    printf 'simctl boot returned: %s\n' "$boot_output" >> "$log_path"
+  fi
 fi
-if ! bootstatus_output="$("$xcrun_bin" simctl bootstatus "$simulator_udid" -b 2>&1)"; then
+bootstatus_arguments=(simctl bootstatus "$simulator_udid")
+if [[ "$bootstatus_boot_if_needed" == true ]]; then
+  bootstatus_arguments+=(-b)
+fi
+if ! bootstatus_output="$("$xcrun_bin" "${bootstatus_arguments[@]}" 2>&1)"; then
   fail "Simulator $simulator_udid did not finish booting: $bootstatus_output"
 fi
 if ! install_output="$("$xcrun_bin" simctl install "$simulator_udid" "$app_path" 2>&1)"; then
@@ -165,9 +254,9 @@ if ! launch_output="$("$xcrun_bin" simctl launch --terminate-running-process "$s
   collect_failure_log
   exit 1
 fi
-printf '%s\n' "$launch_output" | tee -a "$log_path"
+printf '%s\n' "$launch_output" >> "$log_path"
 escaped_bundle_id="${bundle_id//./\\.}"
-launched_pid="$(printf '%s\n' "$launch_output" | sed -nE "s/^${escaped_bundle_id}: ([0-9]+)$/\\1/p" | tail -1)"
+launched_pid="$(printf '%s\n' "$launch_output" | sed -nE "s/^${escaped_bundle_id}: ([1-9][0-9]*)$/\\1/p" | tail -1)"
 if [[ -z "$launched_pid" ]]; then
   record_failure "simctl launch did not return a PID for $bundle_id."
   collect_failure_log
@@ -176,7 +265,16 @@ fi
 
 for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
   "$sleep_bin" 1
-  if ! process_command="$("$ps_bin" -ww -p "$launched_pid" -o comm= 2>/dev/null)" || [[ "${process_command##*/}" != "$executable" ]]; then
+  # BSD ps returns the full executable path for comm=. Bind that path to the
+  # selected simulator and reject a crashed process waiting to be reaped.
+  if ! process_status="$("$ps_bin" -ww -p "$launched_pid" -o state= -o comm= 2>/dev/null)"; then
+    process_status=
+  fi
+  read -r process_state process_command <<< "$process_status" || true
+  if [[ -z "$process_status" \
+    || "$process_state" == Z* \
+    || "${process_command##*/}" != "$executable" \
+    || "$process_command" != *"/Devices/$simulator_udid/"* ]]; then
     record_failure "$bundle_id exited or changed identity after ${elapsed}s of the ${survival_seconds}s survival window."
     collect_failure_log
     exit 1

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -11,7 +11,8 @@ sleep_bin="${SLEEP_BIN:-sleep}"
 app_path="${APP_PATH:-}"
 expected_ios_major="${EXPECTED_IOS_MAJOR:-}"
 survival_seconds="${SURVIVAL_SECONDS:-10}"
-log_path="${LAUNCH_LOG_PATH:-${RUNNER_TEMP:-/tmp}/ios-simulator-launch-${BASHPID:-$$}.log}"
+requested_log_path="${LAUNCH_LOG_PATH:-}"
+log_path="${requested_log_path:-${RUNNER_TEMP:-/tmp}/ios-simulator-launch-${BASHPID:-$$}.log}"
 bundle_id=unknown
 executable=unknown
 sdk_name=unknown
@@ -26,6 +27,7 @@ failure_recorded=false
 
 early_failure() {
   local message="$1"
+  local reason="${2:-invalid-input}"
   local annotation_message="${message//'%'/'%25'}"
   annotation_message="${annotation_message//$'\r'/'%0D'}"
   annotation_message="${annotation_message//$'\n'/'%0A'}"
@@ -39,7 +41,7 @@ early_failure() {
       echo "app-sdk-name=$sdk_name"
       echo "app-sdk-major=$app_sdk_major"
       echo 'classification=launch-failed'
-      echo 'failure-reason=invalid-input'
+      echo "failure-reason=$reason"
       echo 'log-path=unknown'
     } >> "$GITHUB_OUTPUT"
   fi
@@ -48,7 +50,7 @@ early_failure() {
       echo '## iOS simulator launch smoke'
       echo
       echo '**Classification:** launch-failed'
-      echo '**Failure category:** invalid-input'
+      echo "**Failure category:** $reason"
       echo '**Reason:**'
       echo
       echo "    $message"
@@ -62,6 +64,9 @@ if [[ "$log_path" == *$'\r'* || "$log_path" == *$'\n'* ]]; then
   early_failure 'LAUNCH_LOG_PATH must be a single-line path.'
 fi
 if ! mkdir -p "$(dirname "$log_path")" || ! : > "$log_path"; then
+  if [[ -z "$requested_log_path" ]]; then
+    early_failure 'The default launch log path could not be created.' unexpected-error
+  fi
   early_failure 'LAUNCH_LOG_PATH could not be created.'
 fi
 
@@ -387,6 +392,14 @@ for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
     exit 1
   fi
   read -r process_state process_command <<< "$process_status" || true
+  if (( process_status_code == 0 )) \
+    && [[ -n "$process_status" ]] \
+    && { [[ ! "$process_state" =~ ^[A-Z][A-Za-z+\<\>]*$ ]] || [[ "$process_command" != /* ]]; }; then
+    record_failure unexpected-error \
+      "Could not parse the process inspection result after ${elapsed}s: $(single_line "$process_status")"
+    collect_failure_log
+    exit 1
+  fi
   if [[ -z "$process_status" \
     || "$process_state" != [RSIU]* \
     || "${process_command##*/}" != "$executable" \

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -256,7 +256,8 @@ if [[ "$initial_state" == "Shutdown" ]]; then
   else
     # A device observed while transitioning can reject a duplicate boot. Let
     # bootstatus be the authoritative readiness check. Re-read state first so
-    # cleanup never shuts down a simulator another process booted in the race.
+    # this narrows the chance that cleanup shuts down a simulator another
+    # process booted in the race. Shared simulator ownership is unsupported.
     printf 'simctl boot returned: %s\n' "$boot_output" >> "$log_path"
     if current_state="$("$xcrun_bin" simctl list devices available --json 2>> "$log_path" | "$python_bin" -c '
 import json

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -37,8 +37,20 @@ early_failure() {
       echo "app-sdk-major=$app_sdk_major"
       echo 'classification=launch-failed'
       echo 'failure-reason=invalid-input'
-      echo 'log-path='
+      echo 'log-path=unknown'
     } >> "$GITHUB_OUTPUT"
+  fi
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo '## iOS simulator launch smoke'
+      echo
+      echo '**Classification:** launch-failed'
+      echo '**Failure category:** invalid-input'
+      echo '**Reason:**'
+      echo
+      echo "    $message"
+      echo "**Failure log:** \`unknown\`"
+    } >> "$GITHUB_STEP_SUMMARY"
   fi
   exit 1
 }

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -235,13 +235,14 @@ fi
 
 collect_failure_log() {
   local failure_log
+  local diagnostic_window_seconds=$((survival_seconds + 60))
   failure_log="$({
     echo
     echo "===== Simulator log for $executable ====="
     "$xcrun_bin" simctl spawn "$simulator_udid" log show \
-      --last 2m \
+      --last "${diagnostic_window_seconds}s" \
       --style compact \
-      --predicate "process == '$executable'" || true
+      --predicate "process == '$executable' OR process == 'SpringBoard' OR process == 'ReportCrash' OR process == 'launchd_sim'" || true
   } 2>&1)"
   # App-controlled log lines may look like GitHub workflow commands. Preserve
   # them in the artifact without replaying them through the runner console.
@@ -340,7 +341,9 @@ for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
     process_status=
   fi
   if (( process_status_code > 1 )); then
-    fail unexpected-error "Could not inspect the launched process after ${elapsed}s."
+    record_failure unexpected-error "Could not inspect the launched process after ${elapsed}s."
+    collect_failure_log
+    exit 1
   fi
   read -r process_state process_command <<< "$process_status" || true
   if [[ -z "$process_status" \

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+xcrun_bin="${XCRUN_BIN:-xcrun}"
+python_bin="${PYTHON_BIN:-python3}"
+plist_buddy_bin="${PLIST_BUDDY_BIN:-/usr/libexec/PlistBuddy}"
+ps_bin="${PS_BIN:-ps}"
+sleep_bin="${SLEEP_BIN:-sleep}"
+
+app_path="${APP_PATH:?APP_PATH is required}"
+expected_ios_major="${EXPECTED_IOS_MAJOR:-}"
+survival_seconds="${SURVIVAL_SECONDS:-5}"
+log_path="${LAUNCH_LOG_PATH:-${RUNNER_TEMP:-/tmp}/ios-simulator-launch.log}"
+bundle_id=unknown
+executable=unknown
+sdk_name=unknown
+app_sdk_major=unknown
+simulator_udid=unknown
+simulator_runtime=unknown
+initial_state=unknown
+launched_pid=
+booted_by_script=false
+installed=false
+
+mkdir -p "$(dirname "$log_path")"
+: > "$log_path"
+
+record_failure() {
+  local message="$1"
+  echo "$message" | tee -a "$log_path" >&2
+  echo "::error title=iOS simulator launch smoke::$message"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "bundle-id=$bundle_id"
+      echo "launched-pid=$launched_pid"
+      echo "simulator-udid=$simulator_udid"
+      echo "simulator-runtime=$simulator_runtime"
+      echo "app-sdk-name=$sdk_name"
+      echo "app-sdk-major=$app_sdk_major"
+      echo 'classification=launch-failed'
+      echo "log-path=$log_path"
+    } >> "$GITHUB_OUTPUT"
+  fi
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo '## iOS simulator launch smoke'
+      echo
+      echo '**Classification:** launch-failed'
+      echo "**Reason:** $message"
+      echo "**App SDK:** \`$sdk_name\`"
+      echo "**Runtime:** \`$simulator_runtime\`"
+      echo "**Failure log:** \`$log_path\`"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+fail() {
+  record_failure "$1"
+  exit 1
+}
+
+if [[ ! -d "$app_path" || ! -f "$app_path/Info.plist" ]]; then
+  fail "Built simulator app is missing or has no Info.plist: $app_path"
+fi
+if [[ ! "$expected_ios_major" =~ ^[0-9]+$ ]]; then
+  fail 'EXPECTED_IOS_MAJOR must be a whole number.'
+fi
+if [[ ! "$survival_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  fail 'SURVIVAL_SECONDS must be a positive whole number.'
+fi
+
+if ! bundle_id="$("$plist_buddy_bin" -c 'Print :CFBundleIdentifier' "$app_path/Info.plist" 2>&1)"; then
+  fail "The built app has no readable CFBundleIdentifier: $bundle_id"
+fi
+if ! executable="$("$plist_buddy_bin" -c 'Print :CFBundleExecutable' "$app_path/Info.plist" 2>&1)"; then
+  fail "The built app has no readable CFBundleExecutable: $executable"
+fi
+if ! sdk_name="$("$plist_buddy_bin" -c 'Print :DTSDKName' "$app_path/Info.plist" 2>&1)"; then
+  fail "The built app has no readable DTSDKName: $sdk_name"
+fi
+if [[ ! "$sdk_name" =~ ^iphonesimulator([0-9]+)(\.[0-9]+)?$ ]]; then
+  fail "The built app is not an iPhone simulator product: DTSDKName=$sdk_name"
+fi
+app_sdk_major="${BASH_REMATCH[1]}"
+
+if ! selection="$("$xcrun_bin" simctl list devices available --json | "$python_bin" -c '
+import json
+import re
+import sys
+
+expected = int(sys.argv[1])
+payload = json.load(sys.stdin)
+candidates = []
+for runtime, devices in payload.get("devices", {}).items():
+    match = re.search(r"SimRuntime\.iOS-([0-9]+)(?:-([0-9]+))?", runtime)
+    if not match:
+        continue
+    major = int(match.group(1))
+    minor = int(match.group(2) or 0)
+    if major != expected:
+        continue
+    for device in devices:
+        if not device.get("isAvailable", True) or "iPhone" not in device.get("name", ""):
+            continue
+        state = device.get("state", "Shutdown")
+        candidates.append((major, minor, state == "Booted", device["udid"], state, runtime))
+
+if not candidates:
+    sys.exit("No available iPhone simulator matches the requested iOS runtime.")
+candidates.sort(reverse=True)
+_, _, _, udid, state, runtime = candidates[0]
+print(f"{udid}\t{state}\t{runtime}")
+' "$expected_ios_major" 2>&1)"; then
+  fail "Could not select an iPhone simulator for iOS $expected_ios_major: $selection"
+fi
+
+IFS=$'\t' read -r simulator_udid initial_state simulator_runtime <<< "$selection"
+if (( expected_ios_major != app_sdk_major )); then
+  fail "The app SDK $sdk_name does not match the requested iOS $expected_ios_major validation runtime."
+fi
+
+collect_failure_log() {
+  local failure_log
+  failure_log="$({
+    echo
+    echo "===== Simulator log for $executable ====="
+    "$xcrun_bin" simctl spawn "$simulator_udid" log show \
+      --last 2m \
+      --style compact \
+      --predicate "process == '$executable'" || true
+  } 2>&1)"
+  printf '%s\n' "$failure_log" | tee -a "$log_path"
+}
+
+cleanup() {
+  if [[ "$installed" == true ]]; then
+    "$xcrun_bin" simctl terminate "$simulator_udid" "$bundle_id" >/dev/null 2>&1 || true
+    "$xcrun_bin" simctl uninstall "$simulator_udid" "$bundle_id" >/dev/null 2>&1 || true
+  fi
+  if [[ "$booted_by_script" == true ]]; then
+    "$xcrun_bin" simctl shutdown "$simulator_udid" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [[ "$initial_state" != "Booted" ]]; then
+  if ! boot_output="$("$xcrun_bin" simctl boot "$simulator_udid" 2>&1)"; then
+    fail "Could not boot simulator $simulator_udid: $boot_output"
+  fi
+  booted_by_script=true
+fi
+if ! bootstatus_output="$("$xcrun_bin" simctl bootstatus "$simulator_udid" -b 2>&1)"; then
+  fail "Simulator $simulator_udid did not finish booting: $bootstatus_output"
+fi
+if ! install_output="$("$xcrun_bin" simctl install "$simulator_udid" "$app_path" 2>&1)"; then
+  fail "Could not install $bundle_id on simulator $simulator_udid: $install_output"
+fi
+installed=true
+
+if ! launch_output="$("$xcrun_bin" simctl launch --terminate-running-process "$simulator_udid" "$bundle_id" 2>&1)"; then
+  record_failure "simctl could not launch $bundle_id: $launch_output"
+  collect_failure_log
+  exit 1
+fi
+printf '%s\n' "$launch_output" | tee -a "$log_path"
+escaped_bundle_id="${bundle_id//./\\.}"
+launched_pid="$(printf '%s\n' "$launch_output" | sed -nE "s/^${escaped_bundle_id}: ([0-9]+)$/\\1/p" | tail -1)"
+if [[ -z "$launched_pid" ]]; then
+  record_failure "simctl launch did not return a PID for $bundle_id."
+  collect_failure_log
+  exit 1
+fi
+
+for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
+  "$sleep_bin" 1
+  if ! process_command="$("$ps_bin" -ww -p "$launched_pid" -o comm= 2>/dev/null)" || [[ "${process_command##*/}" != "$executable" ]]; then
+    record_failure "$bundle_id exited or changed identity after ${elapsed}s of the ${survival_seconds}s survival window."
+    collect_failure_log
+    exit 1
+  fi
+done
+
+{
+  echo "bundle_id=$bundle_id"
+  echo "launched_pid=$launched_pid"
+  echo "simulator_udid=$simulator_udid"
+  echo "simulator_runtime=$simulator_runtime"
+  echo "app_sdk_name=$sdk_name"
+  echo "app_sdk_major=$app_sdk_major"
+  echo "survival_seconds=$survival_seconds"
+} >> "$log_path"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "bundle-id=$bundle_id"
+    echo "launched-pid=$launched_pid"
+    echo "simulator-udid=$simulator_udid"
+    echo "simulator-runtime=$simulator_runtime"
+    echo "app-sdk-name=$sdk_name"
+    echo "app-sdk-major=$app_sdk_major"
+    echo 'classification=launch-passed'
+    echo "log-path=$log_path"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo '## iOS simulator launch smoke'
+    echo
+    echo '**Classification:** launch-passed'
+    echo "**Bundle identifier:** \`$bundle_id\`"
+    echo "**Runtime:** \`$simulator_runtime\`"
+    echo "**App SDK:** \`$sdk_name\`"
+    echo "**Survival window:** ${survival_seconds}s"
+    echo '**Scope:** install, launch, and process survival only; no callback, push-delivery, signing, or App Store claim'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+echo "$bundle_id remained alive for ${survival_seconds}s after simulator launch."

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -264,17 +264,24 @@ collect_failure_log() {
   trap unexpected_failure ERR
   local failure_log
   local diagnostic_window_seconds=$((survival_seconds + 60))
+  local app_log=
   local simulator_log=
   for _ in 1 2 3 4 5; do
-    simulator_log="$("$xcrun_bin" simctl spawn "$simulator_udid" log show \
+    app_log="$("$xcrun_bin" simctl spawn "$simulator_udid" log show \
       --last "${diagnostic_window_seconds}s" \
       --style compact \
-      --predicate "process == '$executable' OR process == 'SpringBoard' OR process == 'ReportCrash' OR process == 'launchd_sim'" 2>&1 || true)"
-    [[ -z "$simulator_log" ]] || break
+      --predicate "process == '$executable'" 2>/dev/null || true)"
+    [[ -z "$app_log" ]] || break
     "$sleep_bin" 1
   done
+  simulator_log="$("$xcrun_bin" simctl spawn "$simulator_udid" log show \
+    --last "${diagnostic_window_seconds}s" \
+    --style compact \
+    --predicate "process == '$executable' OR process == 'SpringBoard' OR process == 'ReportCrash' OR process == 'launchd_sim'" 2>&1 || true)"
   failure_log="
-===== Simulator log for $executable =====
+===== App log for $executable =====
+$app_log
+===== Simulator diagnostics for $executable =====
 $simulator_log"
   # App-controlled log lines may look like GitHub workflow commands. Preserve
   # them in the artifact without replaying them through the runner console.
@@ -372,7 +379,8 @@ for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
   else
     process_status_code="$?"
   fi
-  if (( process_status_code > 1 )); then
+  if (( process_status_code > 1 )) \
+    || { (( process_status_code == 1 )) && [[ -n "$process_status" ]]; }; then
     record_failure unexpected-error \
       "Could not inspect the launched process after ${elapsed}s: $(single_line "$process_status")"
     collect_failure_log

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -78,6 +78,11 @@ github_command_value() {
 }
 
 record_failure() {
+  # Expected simulator/tool failures are captured in conditionals below, so global errtrace would
+  # incorrectly invoke ERR inside their command substitutions on Bash 3.2. Enable it only while
+  # publishing the already-classified result so a write/helper failure cannot leave empty outputs.
+  set -E
+  trap unexpected_failure ERR
   local reason="$1"
   local message="$2"
   local safe_message
@@ -130,6 +135,7 @@ record_failure() {
       echo "**Failure log:** \`$safe_log_path\`"
     } >> "$GITHUB_STEP_SUMMARY"
   fi
+  set +E
 }
 
 fail() {
@@ -192,6 +198,10 @@ if (( expected_ios_major != app_sdk_major )); then
   fail sdk-mismatch "The app SDK $sdk_name does not match the requested iOS $expected_ios_major validation runtime."
 fi
 
+if ! "$python_bin" --version >> "$log_path" 2>&1; then
+  fail unexpected-error 'The configured Python interpreter is unavailable.'
+fi
+
 if ! selection="$("$xcrun_bin" simctl list devices available --json 2>> "$log_path" | "$python_bin" -c '
 import json
 import re
@@ -234,20 +244,27 @@ if [[ "$selection" == *$'\n'* \
 fi
 
 collect_failure_log() {
+  set -E
+  trap unexpected_failure ERR
   local failure_log
   local diagnostic_window_seconds=$((survival_seconds + 60))
-  failure_log="$({
-    echo
-    echo "===== Simulator log for $executable ====="
-    "$xcrun_bin" simctl spawn "$simulator_udid" log show \
+  local simulator_log=
+  for _ in 1 2 3 4 5; do
+    simulator_log="$("$xcrun_bin" simctl spawn "$simulator_udid" log show \
       --last "${diagnostic_window_seconds}s" \
       --style compact \
-      --predicate "process == '$executable' OR process == 'SpringBoard' OR process == 'ReportCrash' OR process == 'launchd_sim'" || true
-  } 2>&1)"
+      --predicate "process == '$executable' OR process == 'SpringBoard' OR process == 'ReportCrash' OR process == 'launchd_sim'" 2>&1 || true)"
+    [[ -z "$simulator_log" ]] || break
+    "$sleep_bin" 1
+  done
+  failure_log="
+===== Simulator log for $executable =====
+$simulator_log"
   # App-controlled log lines may look like GitHub workflow commands. Preserve
   # them in the artifact without replaying them through the runner console.
   printf '%s\n' "$failure_log" >> "$log_path"
   printf 'Simulator diagnostics were written to %s.\n' "$log_path"
+  set +E
 }
 
 cleanup() {

--- a/github-actions/ios/launch-simulator-app/v1/launch.sh
+++ b/github-actions/ios/launch-simulator-app/v1/launch.sh
@@ -26,7 +26,10 @@ failure_recorded=false
 
 early_failure() {
   local message="$1"
-  echo "::error title=iOS simulator launch smoke::$message"
+  local annotation_message="${message//'%'/'%25'}"
+  annotation_message="${annotation_message//$'\r'/'%0D'}"
+  annotation_message="${annotation_message//$'\n'/'%0A'}"
+  echo "::error title=iOS simulator launch smoke::$annotation_message"
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     {
       echo "bundle-id=$bundle_id"
@@ -80,7 +83,8 @@ github_command_value() {
 record_failure() {
   # Expected simulator/tool failures are captured in conditionals below, so global errtrace would
   # incorrectly invoke ERR inside their command substitutions on Bash 3.2. Enable it only while
-  # publishing the already-classified result so a write/helper failure cannot leave empty outputs.
+  # publishing the already-classified result so a write/helper failure stops publication rather
+  # than letting the action continue with partially written outputs.
   set -E
   trap unexpected_failure ERR
   local reason="$1"
@@ -148,6 +152,9 @@ unexpected_failure() {
   trap - ERR
   if [[ "$failure_recorded" != true ]]; then
     record_failure unexpected-error "An unexpected command failed while running the launch smoke test."
+    if [[ "$installed" == true ]]; then
+      collect_failure_log
+    fi
   fi
   exit "$status"
 }
@@ -170,7 +177,7 @@ fi
 if ! raw_bundle_id="$("$plist_buddy_bin" -c 'Print :CFBundleIdentifier' "$app_path/Info.plist" 2>&1)"; then
   fail invalid-app "The built app has no readable CFBundleIdentifier: $raw_bundle_id"
 fi
-if [[ ! "$raw_bundle_id" =~ ^[A-Za-z0-9.-]+$ ]]; then
+if [[ ! "$raw_bundle_id" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]]; then
   fail invalid-app 'The built app has an invalid CFBundleIdentifier.'
 fi
 bundle_id="$raw_bundle_id"
@@ -181,7 +188,7 @@ fi
 # Spaces are valid in an executable name. Restrict the remaining shape so the
 # value cannot inject GitHub outputs or an NSPredicate used for failure logs.
 executable_pattern='^[-A-Za-z0-9._]+([ ]+[-A-Za-z0-9._]+)*$'
-if [[ ! "$raw_executable" =~ $executable_pattern ]]; then
+if [[ "$raw_executable" == -* || ! "$raw_executable" =~ $executable_pattern ]]; then
   fail invalid-app 'The built app has an invalid CFBundleExecutable.'
 fi
 executable="$raw_executable"
@@ -202,7 +209,12 @@ if ! "$python_bin" --version >> "$log_path" 2>&1; then
   fail unexpected-error 'The configured Python interpreter is unavailable.'
 fi
 
-if ! selection="$("$xcrun_bin" simctl list devices available --json 2>> "$log_path" | "$python_bin" -c '
+if ! devices_json="$("$xcrun_bin" simctl list devices available --json 2>> "$log_path")"; then
+  fail unexpected-error 'simctl could not list available simulator devices.'
+fi
+
+selection_status=0
+selection="$(printf '%s\n' "$devices_json" | "$python_bin" -c '
 import json
 import re
 import sys
@@ -227,12 +239,16 @@ for runtime, devices in payload.get("devices", {}).items():
         candidates.append((state == "Booted", major, minor, device["udid"], state, runtime))
 
 if not candidates:
-    sys.exit("No available iPhone simulator matches the requested iOS runtime.")
+    print("No available iPhone simulator matches the requested iOS runtime.", file=sys.stderr)
+    raise SystemExit(3)
 candidates.sort(reverse=True)
 _, _, _, udid, state, runtime = candidates[0]
 print(f"{udid}\t{state}\t{runtime}")
-' "$expected_ios_major" 2>> "$log_path")"; then
+' "$expected_ios_major" 2>> "$log_path")" || selection_status="$?"
+if (( selection_status == 3 )); then
   fail runtime-unavailable "Could not select an iPhone simulator for iOS $expected_ios_major."
+elif (( selection_status != 0 )); then
+  fail unexpected-error 'The simulator device list could not be parsed.'
 fi
 
 IFS=$'\t' read -r simulator_udid initial_state simulator_runtime <<< "$selection"
@@ -351,14 +367,14 @@ for ((elapsed = 1; elapsed <= survival_seconds; elapsed++)); do
   "$sleep_bin" 1
   # BSD ps returns the full executable path for comm=. Bind that path to the
   # selected simulator and reject a crashed process waiting to be reaped.
-  if process_status="$("$ps_bin" -ww -p "$launched_pid" -o state= -o comm= 2>/dev/null)"; then
+  if process_status="$("$ps_bin" -ww -p "$launched_pid" -o state= -o comm= 2>&1)"; then
     process_status_code=0
   else
     process_status_code="$?"
-    process_status=
   fi
   if (( process_status_code > 1 )); then
-    record_failure unexpected-error "Could not inspect the launched process after ${elapsed}s."
+    record_failure unexpected-error \
+      "Could not inspect the launched process after ${elapsed}s: $(single_line "$process_status")"
     collect_failure_log
     exit 1
   fi

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -Eeuo pipefail
+
+current_case=setup
+report_test_failure() {
+  local status="$?"
+  trap - ERR
+  echo "launch-simulator-app test failed at line $1 while running $current_case" >&2
+  exit "$status"
+}
+trap 'report_test_failure "$LINENO"' ERR
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/launch-ios-simulator-app.XXXXXX")"
@@ -94,6 +103,7 @@ chmod +x "$stub_bin"/*
 run_case() {
   local name="$1"
   shift
+  current_case="$name"
   local case_root="$temporary_root/$name"
   mkdir -p "$case_root"
   : > "$case_root/calls"

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -176,6 +176,9 @@ if run_case process-inspection-failed STUB_PS_EXIT_STATUS=2; then
   exit 1
 fi
 grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/process-inspection-failed/output"
+grep -Fq "simctl spawn SIM-27 log show --last 65s --style compact --predicate process == 'LaunchSmoke' OR process == 'SpringBoard' OR process == 'ReportCrash' OR process == 'launchd_sim'" \
+  "$temporary_root/process-inspection-failed/calls"
+grep -Fq 'stubbed simulator failure log' "$temporary_root/process-inspection-failed/launch.log"
 
 if run_case launch-rejected STUB_LAUNCH_FAILS=true; then
   echo 'Expected a rejected simctl launch to fail.' >&2

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -16,31 +16,56 @@ mkdir -p "$stub_bin"
 cat > "$stub_bin/plist-buddy" <<'STUB'
 #!/usr/bin/env bash
 case "$2" in
-  *CFBundleIdentifier*) printf '%s\n' 'io.customer.test.launch-smoke' ;;
-  *CFBundleExecutable*) printf '%s\n' 'LaunchSmoke' ;;
-  *DTSDKName*) printf '%s\n' 'iphonesimulator27.0' ;;
+  *CFBundleIdentifier*) key=CFBundleIdentifier; value="${STUB_BUNDLE_ID:-io.customer.test.launch-smoke}" ;;
+  *CFBundleExecutable*) key=CFBundleExecutable; value="${STUB_EXECUTABLE:-LaunchSmoke}" ;;
+  *DTSDKName*) key=DTSDKName; value="${STUB_SDK_NAME:-iphonesimulator27.0}" ;;
   *) exit 2 ;;
 esac
+[[ "${STUB_PLIST_FAIL_KEY:-}" != "$key" ]] || exit 2
+printf '%s\n' "$value"
 STUB
 
 cat > "$stub_bin/xcrun" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$STUB_CALLS"
 if [[ "$1 $2 $3 $4" == 'simctl list devices available' ]]; then
-  cat <<'JSON'
+  [[ "${STUB_LIST_WARNING:-false}" != true ]] || echo 'stubbed simctl warning' >&2
+  if [[ "${STUB_NO_DEVICES:-false}" == true ]]; then
+    printf '%s\n' '{"devices":{}}'
+  elif [[ "${STUB_DEVICE_BOOTED:-false}" == true ]]; then
+    cat <<'JSON'
+{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Booted","isAvailable":true,"name":"iPhone 17 Pro","udid":"SIM-27"}]}}
+JSON
+  elif [[ "${STUB_TRANSITIONAL_DEVICE:-false}" == true ]]; then
+    cat <<'JSON'
+{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Shutting Down","isAvailable":true,"name":"iPhone Transitional","udid":"ZZZ-TRANSITIONAL"},{"state":"Shutdown","isAvailable":true,"name":"iPhone 17 Pro","udid":"SIM-27"}]}}
+JSON
+  else
+    cat <<'JSON'
 {"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Shutdown","isAvailable":true,"name":"iPhone 17 Pro","udid":"SIM-27"}],"com.apple.CoreSimulator.SimRuntime.iOS-26-5":[{"state":"Booted","isAvailable":true,"name":"iPhone 16","udid":"SIM-26"}]}}
 JSON
+  fi
+elif [[ "$1 $2" == 'simctl boot' && "${STUB_BOOT_FAILS:-false}" == true ]]; then
+  echo 'stubbed boot transition rejection' >&2
+  exit 3
+elif [[ "$1 $2" == 'simctl bootstatus' && "${STUB_BOOTSTATUS_FAILS:-false}" == true ]]; then
+  echo 'stubbed bootstatus rejection' >&2
+  exit 3
+elif [[ "$1 $2" == 'simctl install' && "${STUB_INSTALL_FAILS:-false}" == true ]]; then
+  echo 'stubbed install rejection' >&2
+  exit 3
 elif [[ "$1 $2" == 'simctl launch' ]]; then
   if [[ "${STUB_LAUNCH_FAILS:-false}" == true ]]; then
-    echo 'stubbed launch rejection' >&2
+    printf '%s\n' 'stubbed launch rejection' '::warning title=forged::must-not-run' >&2
     exit 3
   elif [[ "${STUB_LAUNCH_MALFORMED:-false}" == true ]]; then
     echo 'launch completed without pid'
   else
+    [[ "${STUB_LAUNCH_WARNING:-false}" != true ]] || echo '::notice title=forged::must-not-run'
     echo 'io.customer.test.launch-smoke: 4242'
   fi
 elif [[ "$1 $2" == 'simctl spawn' ]]; then
-  echo 'stubbed simulator failure log'
+  printf '%s\n' 'stubbed simulator failure log' '::warning title=forged-log::must-not-run'
 fi
 STUB
 
@@ -48,7 +73,9 @@ cat > "$stub_bin/ps" <<'STUB'
 #!/usr/bin/env bash
 printf 'ps %s\n' "$*" >> "$STUB_CALLS"
 [[ "${STUB_PROCESS_ALIVE:-true}" == true ]] || exit 1
-printf '%s\n' '/Users/runner/Library/Developer/CoreSimulator/Devices/00000000-0000-0000-0000-000000000000/data/Containers/Bundle/Application/11111111-1111-1111-1111-111111111111/LaunchSmoke.app/LaunchSmoke'
+printf '%s %s\n' \
+  "${STUB_PROCESS_STATE:-S}" \
+  "${STUB_PROCESS_COMMAND:-/Users/runner/Library/Developer/CoreSimulator/Devices/${STUB_DEVICE_UDID:-SIM-27}/data/Containers/Bundle/Application/11111111-1111-1111-1111-111111111111/LaunchSmoke.app/LaunchSmoke}"
 STUB
 
 cat > "$stub_bin/sleep" <<'STUB'
@@ -77,8 +104,9 @@ run_case() {
     PS_BIN="$stub_bin/ps" \
     SLEEP_BIN="$stub_bin/sleep" \
     STUB_CALLS="$case_root/calls" \
+    STUB_DEVICE_UDID=SIM-27 \
     "$@" \
-    bash "$script_dir/launch.sh"
+    bash "$script_dir/launch.sh" > "$case_root/command.log" 2>&1
 }
 
 run_case success
@@ -91,11 +119,18 @@ grep -Fxq 'app-sdk-major=27' "$temporary_root/success/output"
 grep -Fxq 'simctl boot SIM-27' "$temporary_root/success/calls"
 grep -Fxq "simctl install SIM-27 $app_path" "$temporary_root/success/calls"
 grep -Fxq 'simctl launch --terminate-running-process SIM-27 io.customer.test.launch-smoke' "$temporary_root/success/calls"
-test "$(grep -Fxc 'ps -ww -p 4242 -o comm=' "$temporary_root/success/calls")" -eq 5
+test "$(grep -Fxc 'ps -ww -p 4242 -o state= -o comm=' "$temporary_root/success/calls")" -eq 5
 grep -Fxq 'simctl terminate SIM-27 io.customer.test.launch-smoke' "$temporary_root/success/calls"
 grep -Fxq 'simctl uninstall SIM-27 io.customer.test.launch-smoke' "$temporary_root/success/calls"
 grep -Fxq 'simctl shutdown SIM-27' "$temporary_root/success/calls"
 grep -Fq '**Classification:** launch-passed' "$temporary_root/success/summary"
+
+run_case launch-warning STUB_LAUNCH_WARNING=true
+grep -Fq '::notice title=forged::must-not-run' "$temporary_root/launch-warning/launch.log"
+if grep -Fxq '::notice title=forged::must-not-run' "$temporary_root/launch-warning/command.log"; then
+  echo 'simctl launch output emitted a forged GitHub workflow command.' >&2
+  exit 1
+fi
 
 if run_case process-exited STUB_PROCESS_ALIVE=false; then
   echo 'Expected an app that exits during the survival window to fail.' >&2
@@ -110,6 +145,16 @@ if run_case launch-rejected STUB_LAUNCH_FAILS=true; then
 fi
 grep -Fq 'stubbed launch rejection' "$temporary_root/launch-rejected/launch.log"
 grep -Fq 'stubbed simulator failure log' "$temporary_root/launch-rejected/launch.log"
+grep -Fq '::warning title=forged-log::must-not-run' "$temporary_root/launch-rejected/launch.log"
+if grep -Fxq '::warning title=forged::must-not-run' "$temporary_root/launch-rejected/command.log"; then
+  echo 'A multiline tool error emitted a forged GitHub workflow command.' >&2
+  exit 1
+fi
+grep -Fq '%0A::warning title=forged::must-not-run' "$temporary_root/launch-rejected/command.log"
+if grep -Fxq '::warning title=forged-log::must-not-run' "$temporary_root/launch-rejected/command.log"; then
+  echo 'Simulator diagnostics emitted a forged GitHub workflow command.' >&2
+  exit 1
+fi
 
 if run_case malformed-launch STUB_LAUNCH_MALFORMED=true; then
   echo 'Expected launch output without a PID to fail.' >&2
@@ -117,18 +162,177 @@ if run_case malformed-launch STUB_LAUNCH_MALFORMED=true; then
 fi
 grep -Fq 'simctl launch did not return a PID' "$temporary_root/malformed-launch/launch.log"
 
-missing_error="$temporary_root/missing-error"
-if APP_PATH="$temporary_root/Missing.app" EXPECTED_IOS_MAJOR=27 bash "$script_dir/launch.sh" 2>"$missing_error"; then
+if run_case wrong-simulator-process \
+  STUB_PROCESS_COMMAND='/Users/runner/Library/Developer/CoreSimulator/Devices/OTHER-SIM/data/LaunchSmoke.app/LaunchSmoke'; then
+  echo 'Expected a process from another simulator to fail identity validation.' >&2
+  exit 1
+fi
+grep -Fq 'exited or changed identity' "$temporary_root/wrong-simulator-process/launch.log"
+
+if run_case zombie-process STUB_PROCESS_STATE=Z+; then
+  echo 'Expected a zombie process to fail the survival check.' >&2
+  exit 1
+fi
+grep -Fq 'exited or changed identity' "$temporary_root/zombie-process/launch.log"
+
+if run_case invalid-bundle-id STUB_BUNDLE_ID=$'io.customer.test\ninjected=value'; then
+  echo 'Expected an invalid bundle identifier to fail.' >&2
+  exit 1
+fi
+grep -Fq 'invalid CFBundleIdentifier' "$temporary_root/invalid-bundle-id/launch.log"
+if grep -Fq 'injected=value' "$temporary_root/invalid-bundle-id/output"; then
+  echo 'Invalid bundle metadata injected a forged GitHub output.' >&2
+  exit 1
+fi
+grep -Fxq 'bundle-id=unknown' "$temporary_root/invalid-bundle-id/output"
+
+if run_case invalid-executable STUB_EXECUTABLE=$'LaunchSmoke\ninjected=value'; then
+  echo 'Expected an invalid executable name to fail.' >&2
+  exit 1
+fi
+grep -Fq 'invalid CFBundleExecutable' "$temporary_root/invalid-executable/launch.log"
+
+if run_case invalid-sdk-name STUB_SDK_NAME=$'iphonesimulator27.0\ninjected=value'; then
+  echo 'Expected an invalid SDK name to fail.' >&2
+  exit 1
+fi
+grep -Fq 'not an iPhone simulator product' "$temporary_root/invalid-sdk-name/launch.log"
+if grep -Fq 'injected=value' "$temporary_root/invalid-sdk-name/output"; then
+  echo 'Invalid SDK metadata injected a forged GitHub output.' >&2
+  exit 1
+fi
+grep -Fxq 'app-sdk-name=unknown' "$temporary_root/invalid-sdk-name/output"
+
+if run_case unreadable-sdk STUB_PLIST_FAIL_KEY=DTSDKName; then
+  echo 'Expected an unreadable SDK name to fail.' >&2
+  exit 1
+fi
+grep -Fq 'no readable DTSDKName' "$temporary_root/unreadable-sdk/launch.log"
+
+for key in CFBundleIdentifier CFBundleExecutable; do
+  case_name="unreadable-$key"
+  if run_case "$case_name" STUB_PLIST_FAIL_KEY="$key"; then
+    echo "Expected an unreadable $key to fail." >&2
+    exit 1
+  fi
+  grep -Fq "no readable $key" "$temporary_root/$case_name/launch.log"
+done
+
+if run_case device-missing STUB_NO_DEVICES=true; then
+  echo 'Expected a missing matching simulator to fail.' >&2
+  exit 1
+fi
+grep -Fq 'No available iPhone simulator matches' "$temporary_root/device-missing/launch.log"
+
+run_case selection-warning STUB_LIST_WARNING=true
+grep -Fq 'stubbed simctl warning' "$temporary_root/selection-warning/launch.log"
+grep -Fxq 'simulator-udid=SIM-27' "$temporary_root/selection-warning/output"
+
+if run_case sdk-mismatch STUB_SDK_NAME=iphonesimulator26.5; then
+  echo 'Expected an app SDK/runtime mismatch to fail.' >&2
+  exit 1
+fi
+grep -Fq 'does not match the requested iOS 27' "$temporary_root/sdk-mismatch/launch.log"
+
+if run_case zero-padded-sdk STUB_SDK_NAME=iphonesimulator08.0; then
+  echo 'Expected a zero-padded mismatched SDK major to fail.' >&2
+  exit 1
+fi
+grep -Fq 'does not match the requested iOS 27' "$temporary_root/zero-padded-sdk/launch.log"
+
+run_case zero-padded-sdk-match STUB_SDK_NAME=iphonesimulator027.0
+grep -Fxq 'classification=launch-passed' "$temporary_root/zero-padded-sdk-match/output"
+grep -Fxq 'app-sdk-major=27' "$temporary_root/zero-padded-sdk-match/output"
+
+if run_case boot-transition STUB_BOOT_FAILS=true; then
+  : # bootstatus is authoritative and the transitioning simulator became ready.
+else
+  echo 'Expected bootstatus to recover from a duplicate/transitional boot rejection.' >&2
+  exit 1
+fi
+grep -Fq 'stubbed boot transition rejection' "$temporary_root/boot-transition/launch.log"
+
+run_case already-booted STUB_DEVICE_BOOTED=true
+if grep -Fq 'simctl boot SIM-27' "$temporary_root/already-booted/calls" \
+  || grep -Fq 'simctl shutdown SIM-27' "$temporary_root/already-booted/calls"; then
+  echo 'The action mutated the lifecycle of a simulator that was already booted.' >&2
+  exit 1
+fi
+
+run_case transitional-device STUB_TRANSITIONAL_DEVICE=true
+grep -Fxq 'simulator-udid=SIM-27' "$temporary_root/transitional-device/output"
+if grep -Fq 'ZZZ-TRANSITIONAL' "$temporary_root/transitional-device/calls"; then
+  echo 'The action selected a simulator in an unsupported transitional state.' >&2
+  exit 1
+fi
+
+run_case executable-with-space \
+  STUB_EXECUTABLE='Launch Smoke' \
+  STUB_PROCESS_COMMAND='/Users/runner/Library/Developer/CoreSimulator/Devices/SIM-27/data/Launch Smoke.app/Launch Smoke'
+grep -Fxq 'classification=launch-passed' "$temporary_root/executable-with-space/output"
+
+if run_case bootstatus-rejected STUB_BOOTSTATUS_FAILS=true; then
+  echo 'Expected bootstatus failure to fail.' >&2
+  exit 1
+fi
+grep -Fq 'did not finish booting' "$temporary_root/bootstatus-rejected/launch.log"
+
+if run_case install-rejected STUB_INSTALL_FAILS=true; then
+  echo 'Expected install failure to fail.' >&2
+  exit 1
+fi
+grep -Fq 'stubbed install rejection' "$temporary_root/install-rejected/launch.log"
+
+if run_case missing-app APP_PATH="$temporary_root/Missing.app"; then
   echo 'Expected a missing app to fail.' >&2
   exit 1
 fi
-grep -Fq 'Built simulator app is missing or has no Info.plist' "$missing_error"
+grep -Fq 'Built simulator app is missing or has no Info.plist' "$temporary_root/missing-app/launch.log"
 
-survival_error="$temporary_root/survival-error"
-if APP_PATH="$app_path" EXPECTED_IOS_MAJOR=27 SURVIVAL_SECONDS=0 bash "$script_dir/launch.sh" 2>"$survival_error"; then
+if run_case missing-app-input APP_PATH=; then
+  echo 'Expected an empty app path to fail through the action contract.' >&2
+  exit 1
+fi
+grep -Fq 'APP_PATH is required' "$temporary_root/missing-app-input/launch.log"
+grep -Fxq 'classification=launch-failed' "$temporary_root/missing-app-input/output"
+
+if run_case invalid-survival SURVIVAL_SECONDS=0; then
   echo 'Expected an invalid survival window to fail.' >&2
   exit 1
 fi
-grep -Fq 'SURVIVAL_SECONDS must be a positive whole number' "$survival_error"
+grep -Fq 'SURVIVAL_SECONDS must be a whole number from 1 through 120' "$temporary_root/invalid-survival/launch.log"
+
+if run_case excessive-survival SURVIVAL_SECONDS=121; then
+  echo 'Expected an excessive survival window to fail.' >&2
+  exit 1
+fi
+grep -Fq 'SURVIVAL_SECONDS must be a whole number from 1 through 120' "$temporary_root/excessive-survival/launch.log"
+
+if run_case invalid-ios-major EXPECTED_IOS_MAJOR=019; then
+  echo 'Expected a zero-padded iOS major to fail.' >&2
+  exit 1
+fi
+grep -Fq 'EXPECTED_IOS_MAJOR must be a positive whole number' "$temporary_root/invalid-ios-major/launch.log"
+
+if run_case invalid-log-path LAUNCH_LOG_PATH=$'/tmp/launch.log\ninjected=value'; then
+  echo 'Expected a multiline log path to fail.' >&2
+  exit 1
+fi
+grep -Fq 'LAUNCH_LOG_PATH must be a single-line path' "$temporary_root/invalid-log-path/command.log"
+if [[ -e "$temporary_root/invalid-log-path/output" ]]; then
+  grep -Fxq 'classification=launch-failed' "$temporary_root/invalid-log-path/output"
+else
+  echo 'A rejected log path did not publish its failure classification.' >&2
+  exit 1
+fi
+
+unwritable_parent="$temporary_root/unwritable-parent"
+touch "$unwritable_parent"
+if run_case unwritable-log-path LAUNCH_LOG_PATH="$unwritable_parent/launch.log"; then
+  echo 'Expected an uncreatable log path to fail.' >&2
+  exit 1
+fi
+grep -Fq 'LAUNCH_LOG_PATH could not be created' "$temporary_root/unwritable-log-path/command.log"
+grep -Fxq 'classification=launch-failed' "$temporary_root/unwritable-log-path/output"
 
 echo 'launch-simulator-app tests passed'

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/launch-ios-simulator-app.XXXXXX")"
+trap 'rm -rf "$temporary_root"' EXIT
+
+app_path="$temporary_root/Test.app"
+mkdir -p "$app_path"
+touch "$app_path/Info.plist"
+
+stub_bin="$temporary_root/bin"
+mkdir -p "$stub_bin"
+
+cat > "$stub_bin/plist-buddy" <<'STUB'
+#!/usr/bin/env bash
+case "$2" in
+  *CFBundleIdentifier*) printf '%s\n' 'io.customer.test.launch-smoke' ;;
+  *CFBundleExecutable*) printf '%s\n' 'LaunchSmoke' ;;
+  *DTSDKName*) printf '%s\n' 'iphonesimulator27.0' ;;
+  *) exit 2 ;;
+esac
+STUB
+
+cat > "$stub_bin/xcrun" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$STUB_CALLS"
+if [[ "$1 $2 $3 $4" == 'simctl list devices available' ]]; then
+  cat <<'JSON'
+{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Shutdown","isAvailable":true,"name":"iPhone 17 Pro","udid":"SIM-27"}],"com.apple.CoreSimulator.SimRuntime.iOS-26-5":[{"state":"Booted","isAvailable":true,"name":"iPhone 16","udid":"SIM-26"}]}}
+JSON
+elif [[ "$1 $2" == 'simctl launch' ]]; then
+  if [[ "${STUB_LAUNCH_FAILS:-false}" == true ]]; then
+    echo 'stubbed launch rejection' >&2
+    exit 3
+  elif [[ "${STUB_LAUNCH_MALFORMED:-false}" == true ]]; then
+    echo 'launch completed without pid'
+  else
+    echo 'io.customer.test.launch-smoke: 4242'
+  fi
+elif [[ "$1 $2" == 'simctl spawn' ]]; then
+  echo 'stubbed simulator failure log'
+fi
+STUB
+
+cat > "$stub_bin/ps" <<'STUB'
+#!/usr/bin/env bash
+printf 'ps %s\n' "$*" >> "$STUB_CALLS"
+[[ "${STUB_PROCESS_ALIVE:-true}" == true ]] || exit 1
+printf '%s\n' '/Users/runner/Library/Developer/CoreSimulator/Devices/00000000-0000-0000-0000-000000000000/data/Containers/Bundle/Application/11111111-1111-1111-1111-111111111111/LaunchSmoke.app/LaunchSmoke'
+STUB
+
+cat > "$stub_bin/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+chmod +x "$stub_bin"/*
+
+run_case() {
+  local name="$1"
+  shift
+  local case_root="$temporary_root/$name"
+  mkdir -p "$case_root"
+  : > "$case_root/calls"
+  env \
+    APP_PATH="$app_path" \
+    EXPECTED_IOS_MAJOR=27 \
+    SURVIVAL_SECONDS=5 \
+    LAUNCH_LOG_PATH="$case_root/launch.log" \
+    GITHUB_OUTPUT="$case_root/output" \
+    GITHUB_STEP_SUMMARY="$case_root/summary" \
+    XCRUN_BIN="$stub_bin/xcrun" \
+    PYTHON_BIN=python3 \
+    PLIST_BUDDY_BIN="$stub_bin/plist-buddy" \
+    PS_BIN="$stub_bin/ps" \
+    SLEEP_BIN="$stub_bin/sleep" \
+    STUB_CALLS="$case_root/calls" \
+    "$@" \
+    bash "$script_dir/launch.sh"
+}
+
+run_case success
+grep -Fxq 'bundle-id=io.customer.test.launch-smoke' "$temporary_root/success/output"
+grep -Fxq 'launched-pid=4242' "$temporary_root/success/output"
+grep -Fxq 'classification=launch-passed' "$temporary_root/success/output"
+grep -Fxq 'simulator-runtime=com.apple.CoreSimulator.SimRuntime.iOS-27-0' "$temporary_root/success/output"
+grep -Fxq 'app-sdk-name=iphonesimulator27.0' "$temporary_root/success/output"
+grep -Fxq 'app-sdk-major=27' "$temporary_root/success/output"
+grep -Fxq 'simctl boot SIM-27' "$temporary_root/success/calls"
+grep -Fxq "simctl install SIM-27 $app_path" "$temporary_root/success/calls"
+grep -Fxq 'simctl launch --terminate-running-process SIM-27 io.customer.test.launch-smoke' "$temporary_root/success/calls"
+test "$(grep -Fxc 'ps -ww -p 4242 -o comm=' "$temporary_root/success/calls")" -eq 5
+grep -Fxq 'simctl terminate SIM-27 io.customer.test.launch-smoke' "$temporary_root/success/calls"
+grep -Fxq 'simctl uninstall SIM-27 io.customer.test.launch-smoke' "$temporary_root/success/calls"
+grep -Fxq 'simctl shutdown SIM-27' "$temporary_root/success/calls"
+grep -Fq '**Classification:** launch-passed' "$temporary_root/success/summary"
+
+if run_case process-exited STUB_PROCESS_ALIVE=false; then
+  echo 'Expected an app that exits during the survival window to fail.' >&2
+  exit 1
+fi
+grep -Fq 'exited or changed identity after 1s of the 5s survival window' "$temporary_root/process-exited/launch.log"
+grep -Fq 'stubbed simulator failure log' "$temporary_root/process-exited/launch.log"
+
+if run_case launch-rejected STUB_LAUNCH_FAILS=true; then
+  echo 'Expected a rejected simctl launch to fail.' >&2
+  exit 1
+fi
+grep -Fq 'stubbed launch rejection' "$temporary_root/launch-rejected/launch.log"
+grep -Fq 'stubbed simulator failure log' "$temporary_root/launch-rejected/launch.log"
+
+if run_case malformed-launch STUB_LAUNCH_MALFORMED=true; then
+  echo 'Expected launch output without a PID to fail.' >&2
+  exit 1
+fi
+grep -Fq 'simctl launch did not return a PID' "$temporary_root/malformed-launch/launch.log"
+
+missing_error="$temporary_root/missing-error"
+if APP_PATH="$temporary_root/Missing.app" EXPECTED_IOS_MAJOR=27 bash "$script_dir/launch.sh" 2>"$missing_error"; then
+  echo 'Expected a missing app to fail.' >&2
+  exit 1
+fi
+grep -Fq 'Built simulator app is missing or has no Info.plist' "$missing_error"
+
+survival_error="$temporary_root/survival-error"
+if APP_PATH="$app_path" EXPECTED_IOS_MAJOR=27 SURVIVAL_SECONDS=0 bash "$script_dir/launch.sh" 2>"$survival_error"; then
+  echo 'Expected an invalid survival window to fail.' >&2
+  exit 1
+fi
+grep -Fq 'SURVIVAL_SECONDS must be a positive whole number' "$survival_error"
+
+echo 'launch-simulator-app tests passed'

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -162,7 +162,7 @@ if run_case process-exited STUB_PROCESS_ALIVE=false; then
   echo 'Expected an app that exits during the survival window to fail.' >&2
   exit 1
 fi
-grep -Fq 'exited or changed identity after 1s of the 5s survival window' "$temporary_root/process-exited/launch.log"
+grep -Fq 'exited, became non-runnable, or changed identity after 1s of the 5s survival window' "$temporary_root/process-exited/launch.log"
 grep -Fq 'ps observation after 1s:' "$temporary_root/process-exited/launch.log"
 grep -Fxq 'failure-reason=did-not-survive' "$temporary_root/process-exited/output"
 grep -Fxq 'launched-pid=4242' "$temporary_root/process-exited/output"
@@ -207,20 +207,34 @@ if run_case wrong-simulator-process \
   echo 'Expected a process from another simulator to fail identity validation.' >&2
   exit 1
 fi
-grep -Fq 'exited or changed identity' "$temporary_root/wrong-simulator-process/launch.log"
+grep -Fq 'exited, became non-runnable, or changed identity' "$temporary_root/wrong-simulator-process/launch.log"
 
 if run_case wrong-executable-process \
   STUB_PROCESS_COMMAND='/Users/runner/Library/Developer/CoreSimulator/Devices/SIM-27/data/LaunchSmoke.app/OtherExecutable'; then
   echo 'Expected a different executable in the selected simulator to fail identity validation.' >&2
   exit 1
 fi
-grep -Fq 'exited or changed identity' "$temporary_root/wrong-executable-process/launch.log"
+grep -Fq 'exited, became non-runnable, or changed identity' "$temporary_root/wrong-executable-process/launch.log"
 
 if run_case zombie-process STUB_PROCESS_STATE=Z+; then
   echo 'Expected a zombie process to fail the survival check.' >&2
   exit 1
 fi
-grep -Fq 'exited or changed identity' "$temporary_root/zombie-process/launch.log"
+grep -Fq 'exited, became non-runnable, or changed identity' "$temporary_root/zombie-process/launch.log"
+
+if run_case stopped-process STUB_PROCESS_STATE=T; then
+  echo 'Expected a stopped process to fail the survival check.' >&2
+  exit 1
+fi
+grep -Fq 'ps observation after 1s: T ' "$temporary_root/stopped-process/launch.log"
+grep -Fq 'exited, became non-runnable, or changed identity' "$temporary_root/stopped-process/launch.log"
+
+if run_case uninterruptible-process STUB_PROCESS_STATE=U; then
+  echo 'Expected an uninterruptible process to fail the survival check.' >&2
+  exit 1
+fi
+grep -Fq 'ps observation after 1s: U ' "$temporary_root/uninterruptible-process/launch.log"
+grep -Fq 'exited, became non-runnable, or changed identity' "$temporary_root/uninterruptible-process/launch.log"
 
 if run_case invalid-bundle-id STUB_BUNDLE_ID=$'io.customer.test\ninjected=value'; then
   echo 'Expected an invalid bundle identifier to fail.' >&2

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -39,7 +39,12 @@ cat > "$stub_bin/xcrun" <<'STUB'
 printf '%s\n' "$*" >> "$STUB_CALLS"
   if [[ "$1 $2 $3 $4" == 'simctl list devices available' ]]; then
   [[ "${STUB_LIST_WARNING:-false}" != true ]] || echo 'stubbed simctl warning' >&2
-  if [[ "${STUB_MALFORMED_SELECTION:-false}" == true ]]; then
+  if [[ "${STUB_LIST_FAILS:-false}" == true ]]; then
+    echo 'stubbed simctl list failure' >&2
+    exit 4
+  elif [[ "${STUB_LIST_MALFORMED_JSON:-false}" == true ]]; then
+    printf '%s\n' '{not-json'
+  elif [[ "${STUB_MALFORMED_SELECTION:-false}" == true ]]; then
     printf '%s\n' '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Shutdown","isAvailable":true,"name":"iPhone 17 Pro","udid":"INVALID UDID"}]}}'
   elif [[ "${STUB_BOOT_RACE_OTHER_OWNER:-false}" == true ]] \
     && [[ "$(grep -Fc 'simctl list devices available --json' "$STUB_CALLS")" -gt 1 ]]; then
@@ -95,7 +100,10 @@ cat > "$stub_bin/ps" <<'STUB'
 #!/usr/bin/env bash
 printf 'ps %s\n' "$*" >> "$STUB_CALLS"
 [[ "${STUB_PROCESS_ALIVE:-true}" == true ]] || exit 1
-[[ -z "${STUB_PS_EXIT_STATUS:-}" ]] || exit "$STUB_PS_EXIT_STATUS"
+if [[ -n "${STUB_PS_EXIT_STATUS:-}" ]]; then
+  echo 'stubbed ps inspection error' >&2
+  exit "$STUB_PS_EXIT_STATUS"
+fi
 printf '%s %s\n' \
   "${STUB_PROCESS_STATE:-S}" \
   "${STUB_PROCESS_COMMAND:-/Users/runner/Library/Developer/CoreSimulator/Devices/${STUB_DEVICE_UDID:-SIM-27}/data/Containers/Bundle/Application/11111111-1111-1111-1111-111111111111/LaunchSmoke.app/LaunchSmoke}"
@@ -176,6 +184,7 @@ if run_case process-inspection-failed STUB_PS_EXIT_STATUS=2; then
   exit 1
 fi
 grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/process-inspection-failed/output"
+grep -Fq 'stubbed ps inspection error' "$temporary_root/process-inspection-failed/launch.log"
 grep -Fq "simctl spawn SIM-27 log show --last 65s --style compact --predicate process == 'LaunchSmoke' OR process == 'SpringBoard' OR process == 'ReportCrash' OR process == 'launchd_sim'" \
   "$temporary_root/process-inspection-failed/calls"
 grep -Fq 'stubbed simulator failure log' "$temporary_root/process-inspection-failed/launch.log"
@@ -285,6 +294,20 @@ if run_case device-missing STUB_NO_DEVICES=true; then
 fi
 grep -Fq 'No available iPhone simulator matches' "$temporary_root/device-missing/launch.log"
 grep -Fxq 'failure-reason=runtime-unavailable' "$temporary_root/device-missing/output"
+
+if run_case simulator-list-failed STUB_LIST_FAILS=true; then
+  echo 'Expected a simctl device-list failure to fail.' >&2
+  exit 1
+fi
+grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/simulator-list-failed/output"
+grep -Fq 'stubbed simctl list failure' "$temporary_root/simulator-list-failed/launch.log"
+
+if run_case malformed-device-json STUB_LIST_MALFORMED_JSON=true; then
+  echo 'Expected malformed simctl JSON to fail.' >&2
+  exit 1
+fi
+grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/malformed-device-json/output"
+grep -Fq 'could not be parsed' "$temporary_root/malformed-device-json/launch.log"
 
 run_case selection-warning STUB_LIST_WARNING=true
 grep -Fq 'stubbed simctl warning' "$temporary_root/selection-warning/launch.log"
@@ -399,6 +422,19 @@ if run_case unexpected-command-failure STUB_SLEEP_FAILS=true; then
   exit 1
 fi
 grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/unexpected-command-failure/output"
+grep -Fq 'stubbed simulator failure log' "$temporary_root/unexpected-command-failure/launch.log"
+
+if run_case option-shaped-bundle-id STUB_BUNDLE_ID=-invalid.bundle; then
+  echo 'Expected an option-shaped bundle identifier to fail.' >&2
+  exit 1
+fi
+grep -Fxq 'failure-reason=invalid-app' "$temporary_root/option-shaped-bundle-id/output"
+
+if run_case option-shaped-executable STUB_EXECUTABLE=-LaunchSmoke; then
+  echo 'Expected an option-shaped executable to fail.' >&2
+  exit 1
+fi
+grep -Fxq 'failure-reason=invalid-app' "$temporary_root/option-shaped-executable/output"
 
 if run_case boot-race-other-owner STUB_BOOT_FAILS=true STUB_BOOT_RACE_OTHER_OWNER=true; then
   :

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -28,9 +28,14 @@ STUB
 cat > "$stub_bin/xcrun" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$STUB_CALLS"
-if [[ "$1 $2 $3 $4" == 'simctl list devices available' ]]; then
+  if [[ "$1 $2 $3 $4" == 'simctl list devices available' ]]; then
   [[ "${STUB_LIST_WARNING:-false}" != true ]] || echo 'stubbed simctl warning' >&2
-  if [[ "${STUB_NO_DEVICES:-false}" == true ]]; then
+  if [[ "${STUB_MALFORMED_SELECTION:-false}" == true ]]; then
+    printf '%s\n' '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Shutdown","isAvailable":true,"name":"iPhone 17 Pro","udid":"INVALID UDID"}]}}'
+  elif [[ "${STUB_BOOT_RACE_OTHER_OWNER:-false}" == true ]] \
+    && [[ "$(grep -Fc 'simctl list devices available --json' "$STUB_CALLS")" -gt 1 ]]; then
+    printf '%s\n' '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Booted","isAvailable":true,"name":"iPhone 17 Pro","udid":"SIM-27"}]}}'
+  elif [[ "${STUB_NO_DEVICES:-false}" == true ]]; then
     printf '%s\n' '{"devices":{}}'
   elif [[ "${STUB_DEVICE_BOOTED:-false}" == true ]]; then
     cat <<'JSON'
@@ -80,6 +85,7 @@ STUB
 
 cat > "$stub_bin/sleep" <<'STUB'
 #!/usr/bin/env bash
+[[ "${STUB_SLEEP_FAILS:-false}" != true ]] || exit 9
 exit 0
 STUB
 
@@ -113,6 +119,7 @@ run_case success
 grep -Fxq 'bundle-id=io.customer.test.launch-smoke' "$temporary_root/success/output"
 grep -Fxq 'launched-pid=4242' "$temporary_root/success/output"
 grep -Fxq 'classification=launch-passed' "$temporary_root/success/output"
+grep -Fxq 'failure-reason=none' "$temporary_root/success/output"
 grep -Fxq 'simulator-runtime=com.apple.CoreSimulator.SimRuntime.iOS-27-0' "$temporary_root/success/output"
 grep -Fxq 'app-sdk-name=iphonesimulator27.0' "$temporary_root/success/output"
 grep -Fxq 'app-sdk-major=27' "$temporary_root/success/output"
@@ -137,6 +144,7 @@ if run_case process-exited STUB_PROCESS_ALIVE=false; then
   exit 1
 fi
 grep -Fq 'exited or changed identity after 1s of the 5s survival window' "$temporary_root/process-exited/launch.log"
+grep -Fxq 'failure-reason=did-not-survive' "$temporary_root/process-exited/output"
 grep -Fq 'stubbed simulator failure log' "$temporary_root/process-exited/launch.log"
 
 if run_case launch-rejected STUB_LAUNCH_FAILS=true; then
@@ -144,6 +152,7 @@ if run_case launch-rejected STUB_LAUNCH_FAILS=true; then
   exit 1
 fi
 grep -Fq 'stubbed launch rejection' "$temporary_root/launch-rejected/launch.log"
+grep -Fxq 'failure-reason=launch-failed' "$temporary_root/launch-rejected/output"
 grep -Fq 'stubbed simulator failure log' "$temporary_root/launch-rejected/launch.log"
 grep -Fq '::warning title=forged-log::must-not-run' "$temporary_root/launch-rejected/launch.log"
 if grep -Fxq '::warning title=forged::must-not-run' "$temporary_root/launch-rejected/command.log"; then
@@ -180,6 +189,7 @@ if run_case invalid-bundle-id STUB_BUNDLE_ID=$'io.customer.test\ninjected=value'
   exit 1
 fi
 grep -Fq 'invalid CFBundleIdentifier' "$temporary_root/invalid-bundle-id/launch.log"
+grep -Fxq 'failure-reason=invalid-app' "$temporary_root/invalid-bundle-id/output"
 if grep -Fq 'injected=value' "$temporary_root/invalid-bundle-id/output"; then
   echo 'Invalid bundle metadata injected a forged GitHub output.' >&2
   exit 1
@@ -223,6 +233,7 @@ if run_case device-missing STUB_NO_DEVICES=true; then
   exit 1
 fi
 grep -Fq 'No available iPhone simulator matches' "$temporary_root/device-missing/launch.log"
+grep -Fxq 'failure-reason=runtime-unavailable' "$temporary_root/device-missing/output"
 
 run_case selection-warning STUB_LIST_WARNING=true
 grep -Fq 'stubbed simctl warning' "$temporary_root/selection-warning/launch.log"
@@ -233,6 +244,7 @@ if run_case sdk-mismatch STUB_SDK_NAME=iphonesimulator26.5; then
   exit 1
 fi
 grep -Fq 'does not match the requested iOS 27' "$temporary_root/sdk-mismatch/launch.log"
+grep -Fxq 'failure-reason=sdk-mismatch' "$temporary_root/sdk-mismatch/output"
 
 if run_case zero-padded-sdk STUB_SDK_NAME=iphonesimulator08.0; then
   echo 'Expected a zero-padded mismatched SDK major to fail.' >&2
@@ -276,12 +288,14 @@ if run_case bootstatus-rejected STUB_BOOTSTATUS_FAILS=true; then
   exit 1
 fi
 grep -Fq 'did not finish booting' "$temporary_root/bootstatus-rejected/launch.log"
+grep -Fxq 'failure-reason=simulator-boot-failed' "$temporary_root/bootstatus-rejected/output"
 
 if run_case install-rejected STUB_INSTALL_FAILS=true; then
   echo 'Expected install failure to fail.' >&2
   exit 1
 fi
 grep -Fq 'stubbed install rejection' "$temporary_root/install-rejected/launch.log"
+grep -Fxq 'failure-reason=install-failed' "$temporary_root/install-rejected/output"
 
 if run_case missing-app APP_PATH="$temporary_root/Missing.app"; then
   echo 'Expected a missing app to fail.' >&2
@@ -295,12 +309,37 @@ if run_case missing-app-input APP_PATH=; then
 fi
 grep -Fq 'APP_PATH is required' "$temporary_root/missing-app-input/launch.log"
 grep -Fxq 'classification=launch-failed' "$temporary_root/missing-app-input/output"
+grep -Fxq 'failure-reason=invalid-input' "$temporary_root/missing-app-input/output"
 
 if run_case invalid-survival SURVIVAL_SECONDS=0; then
   echo 'Expected an invalid survival window to fail.' >&2
   exit 1
 fi
 grep -Fq 'SURVIVAL_SECONDS must be a whole number from 1 through 120' "$temporary_root/invalid-survival/launch.log"
+grep -Fxq 'failure-reason=invalid-input' "$temporary_root/invalid-survival/output"
+
+if run_case malformed-selection STUB_MALFORMED_SELECTION=true; then
+  echo 'Expected a malformed selected simulator identity to fail.' >&2
+  exit 1
+fi
+grep -Fxq 'failure-reason=runtime-selection-failed' "$temporary_root/malformed-selection/output"
+
+if run_case unexpected-command-failure STUB_SLEEP_FAILS=true; then
+  echo 'Expected an unexpected sleep failure to fail.' >&2
+  exit 1
+fi
+grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/unexpected-command-failure/output"
+
+if run_case boot-race-other-owner STUB_BOOT_FAILS=true STUB_BOOT_RACE_OTHER_OWNER=true; then
+  :
+else
+  echo 'Expected a simulator booted by another process to become ready.' >&2
+  exit 1
+fi
+if grep -Fq 'simctl shutdown SIM-27' "$temporary_root/boot-race-other-owner/calls"; then
+  echo 'The action shut down a simulator booted by another process.' >&2
+  exit 1
+fi
 
 if run_case excessive-survival SURVIVAL_SECONDS=121; then
   echo 'Expected an excessive survival window to fail.' >&2

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -208,6 +208,13 @@ if run_case wrong-simulator-process \
 fi
 grep -Fq 'exited or changed identity' "$temporary_root/wrong-simulator-process/launch.log"
 
+if run_case wrong-executable-process \
+  STUB_PROCESS_COMMAND='/Users/runner/Library/Developer/CoreSimulator/Devices/SIM-27/data/LaunchSmoke.app/OtherExecutable'; then
+  echo 'Expected a different executable in the selected simulator to fail identity validation.' >&2
+  exit 1
+fi
+grep -Fq 'exited or changed identity' "$temporary_root/wrong-executable-process/launch.log"
+
 if run_case zombie-process STUB_PROCESS_STATE=Z+; then
   echo 'Expected a zombie process to fail the survival check.' >&2
   exit 1
@@ -455,6 +462,7 @@ env \
   SURVIVAL_SECONDS=1 \
   RUNNER_TEMP="$default_log_root" \
   GITHUB_OUTPUT="$default_log_root/output" \
+  GITHUB_STEP_SUMMARY="$default_log_root/summary" \
   XCRUN_BIN="$stub_bin/xcrun" \
   PYTHON_BIN=python3 \
   PLIST_BUDDY_BIN="$stub_bin/plist-buddy" \

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -460,6 +460,7 @@ env \
   APP_PATH="$app_path" \
   EXPECTED_IOS_MAJOR=27 \
   SURVIVAL_SECONDS=1 \
+  LAUNCH_LOG_PATH= \
   RUNNER_TEMP="$default_log_root" \
   GITHUB_OUTPUT="$default_log_root/output" \
   GITHUB_STEP_SUMMARY="$default_log_root/summary" \

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -13,11 +13,11 @@ trap 'report_test_failure "$LINENO"' ERR
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 for production_tool in \
-  'XCRUN_BIN: xcrun' \
-  'PYTHON_BIN: python3' \
+  'XCRUN_BIN: /usr/bin/xcrun' \
+  'PYTHON_BIN: /usr/bin/python3' \
   'PLIST_BUDDY_BIN: /usr/libexec/PlistBuddy' \
-  'PS_BIN: ps' \
-  'SLEEP_BIN: sleep'; do
+  'PS_BIN: /bin/ps' \
+  'SLEEP_BIN: /bin/sleep'; do
   grep -Fq "$production_tool" "$script_dir/action.yml"
 done
 temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/launch-ios-simulator-app.XXXXXX")"
@@ -106,7 +106,13 @@ elif [[ "$1 $2" == 'simctl spawn' ]]; then
       exit 0
     fi
   fi
-  printf '%s\n' 'stubbed simulator failure log' '::warning title=forged-log::must-not-run'
+  if [[ "${STUB_LARGE_LOG:-false}" == true ]]; then
+    for line in {1..3000}; do
+      printf 'stubbed simulator failure log %s\n' "$line"
+    done
+  else
+    printf '%s\n' 'stubbed simulator failure log' '::warning title=forged-log::must-not-run'
+  fi
 fi
 STUB
 
@@ -290,6 +296,15 @@ if run_case malformed-launch STUB_LAUNCH_MALFORMED=true; then
   exit 1
 fi
 grep -Fq 'simctl launch did not return a PID' "$temporary_root/malformed-launch/launch.log"
+
+if run_case bounded-diagnostics STUB_LAUNCH_FAILS=true STUB_LARGE_LOG=true; then
+  echo 'Expected a rejected launch with large diagnostics to fail.' >&2
+  exit 1
+fi
+if (( $(wc -l < "$temporary_root/bounded-diagnostics/launch.log") > 4500 )); then
+  echo 'Expected failure diagnostics to be line-bounded.' >&2
+  exit 1
+fi
 
 if run_case wrong-simulator-process \
   STUB_PROCESS_COMMAND='/Users/runner/Library/Developer/CoreSimulator/Devices/OTHER-SIM/data/LaunchSmoke.app/LaunchSmoke'; then

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -92,6 +92,12 @@ elif [[ "$1 $2" == 'simctl launch' ]]; then
     echo 'io.customer.test.launch-smoke: 4242'
   fi
 elif [[ "$1 $2" == 'simctl spawn' ]]; then
+  if [[ "$*" != *" OR process == "* && -n "${STUB_EMPTY_APP_LOG_ATTEMPTS:-}" ]]; then
+    narrow_count="$(grep -Fxc "simctl spawn SIM-27 log show --last 65s --style compact --predicate process == 'LaunchSmoke'" "$STUB_CALLS")"
+    if (( narrow_count <= STUB_EMPTY_APP_LOG_ATTEMPTS )); then
+      exit 0
+    fi
+  fi
   printf '%s\n' 'stubbed simulator failure log' '::warning title=forged-log::must-not-run'
 fi
 STUB
@@ -124,6 +130,8 @@ run_case() {
   local case_root="$temporary_root/$name"
   mkdir -p "$case_root"
   : > "$case_root/calls"
+  : > "$case_root/output"
+  : > "$case_root/summary"
   env \
     APP_PATH="$app_path" \
     EXPECTED_IOS_MAJOR=27 \
@@ -179,6 +187,15 @@ grep -Fxq 'simctl terminate SIM-27 io.customer.test.launch-smoke' "$temporary_ro
 grep -Fxq 'simctl uninstall SIM-27 io.customer.test.launch-smoke' "$temporary_root/process-exited/calls"
 grep -Fxq 'simctl shutdown SIM-27' "$temporary_root/process-exited/calls"
 
+if run_case process-exited-delayed-log \
+  STUB_PROCESS_ALIVE=false \
+  STUB_EMPTY_APP_LOG_ATTEMPTS=2; then
+  echo 'Expected an exited process with delayed logs to fail.' >&2
+  exit 1
+fi
+test "$(grep -Fxc "simctl spawn SIM-27 log show --last 65s --style compact --predicate process == 'LaunchSmoke'" "$temporary_root/process-exited-delayed-log/calls")" -eq 3
+grep -Fq 'stubbed simulator failure log' "$temporary_root/process-exited-delayed-log/launch.log"
+
 if run_case process-inspection-failed STUB_PS_EXIT_STATUS=2; then
   echo 'Expected a process-inspection failure to fail.' >&2
   exit 1
@@ -188,6 +205,13 @@ grep -Fq 'stubbed ps inspection error' "$temporary_root/process-inspection-faile
 grep -Fq "simctl spawn SIM-27 log show --last 65s --style compact --predicate process == 'LaunchSmoke' OR process == 'SpringBoard' OR process == 'ReportCrash' OR process == 'launchd_sim'" \
   "$temporary_root/process-inspection-failed/calls"
 grep -Fq 'stubbed simulator failure log' "$temporary_root/process-inspection-failed/launch.log"
+
+if run_case process-inspection-status-one-with-error STUB_PS_EXIT_STATUS=1; then
+  echo 'Expected ps status 1 with diagnostic output to be an infrastructure failure.' >&2
+  exit 1
+fi
+grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/process-inspection-status-one-with-error/output"
+grep -Fq 'stubbed ps inspection error' "$temporary_root/process-inspection-status-one-with-error/launch.log"
 
 if run_case launch-rejected STUB_LAUNCH_FAILS=true; then
   echo 'Expected a rejected simctl launch to fail.' >&2

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -122,7 +122,7 @@ run_case() {
     STUB_CALLS="$case_root/calls" \
     STUB_DEVICE_UDID=SIM-27 \
     "$@" \
-    bash "$script_dir/launch.sh" > "$case_root/command.log" 2>&1
+    "$BASH" "$script_dir/launch.sh" > "$case_root/command.log" 2>&1
 }
 
 run_case success
@@ -169,7 +169,8 @@ if grep -Fxq '::warning title=forged::must-not-run' "$temporary_root/launch-reje
   echo 'A multiline tool error emitted a forged GitHub workflow command.' >&2
   exit 1
 fi
-grep -Fq '%0A::warning title=forged::must-not-run' "$temporary_root/launch-rejected/command.log"
+grep -Eq '^::error title=iOS simulator launch smoke::.*stubbed launch rejection.*must-not-run$' \
+  "$temporary_root/launch-rejected/command.log"
 if grep -Fxq '::warning title=forged-log::must-not-run' "$temporary_root/launch-rejected/command.log"; then
   echo 'Simulator diagnostics emitted a forged GitHub workflow command.' >&2
   exit 1

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -297,6 +297,7 @@ grep -Fxq 'simctl bootstatus SIM-27 -b' "$temporary_root/boot-transition/calls"
 grep -Fxq 'simctl shutdown SIM-27' "$temporary_root/boot-transition/calls"
 
 run_case already-booted STUB_DEVICE_BOOTED=true
+grep -Fxq 'simctl bootstatus SIM-27' "$temporary_root/already-booted/calls"
 if grep -Fq 'simctl boot SIM-27' "$temporary_root/already-booted/calls" \
   || grep -Fq 'simctl shutdown SIM-27' "$temporary_root/already-booted/calls"; then
   echo 'The action mutated the lifecycle of a simulator that was already booted.' >&2

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -43,7 +43,11 @@ printf '%s\n' "$*" >> "$STUB_CALLS"
     printf '%s\n' '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Shutdown","isAvailable":true,"name":"iPhone 17 Pro","udid":"INVALID UDID"}]}}'
   elif [[ "${STUB_BOOT_RACE_OTHER_OWNER:-false}" == true ]] \
     && [[ "$(grep -Fc 'simctl list devices available --json' "$STUB_CALLS")" -gt 1 ]]; then
-    printf '%s\n' "{\"devices\":{\"com.apple.CoreSimulator.SimRuntime.iOS-27-0\":[{\"state\":\"${STUB_RACE_STATE:-Booted}\",\"isAvailable\":true,\"name\":\"iPhone 17 Pro\",\"udid\":\"SIM-27\"}]}}"
+    if [[ "${STUB_RACE_DEVICE_MISSING:-false}" == true ]]; then
+      printf '%s\n' '{"devices":{}}'
+    else
+      printf '%s\n' "{\"devices\":{\"com.apple.CoreSimulator.SimRuntime.iOS-27-0\":[{\"state\":\"${STUB_RACE_STATE:-Booted}\",\"isAvailable\":true,\"name\":\"iPhone 17 Pro\",\"udid\":\"SIM-27\"}]}}"
+    fi
   elif [[ "${STUB_NO_DEVICES:-false}" == true ]]; then
     printf '%s\n' '{"devices":{}}'
   elif [[ "${STUB_DEVICE_BOOTED:-false}" == true ]]; then
@@ -289,6 +293,8 @@ else
   exit 1
 fi
 grep -Fq 'stubbed boot transition rejection' "$temporary_root/boot-transition/launch.log"
+grep -Fxq 'simctl bootstatus SIM-27 -b' "$temporary_root/boot-transition/calls"
+grep -Fxq 'simctl shutdown SIM-27' "$temporary_root/boot-transition/calls"
 
 run_case already-booted STUB_DEVICE_BOOTED=true
 if grep -Fq 'simctl boot SIM-27' "$temporary_root/already-booted/calls" \
@@ -374,6 +380,7 @@ if grep -Fq 'simctl shutdown SIM-27' "$temporary_root/boot-race-other-owner/call
   echo 'The action shut down a simulator booted by another process.' >&2
   exit 1
 fi
+grep -Fxq 'simctl bootstatus SIM-27' "$temporary_root/boot-race-other-owner/calls"
 
 run_case boot-race-other-owner-booting \
   STUB_BOOT_FAILS=true \
@@ -383,6 +390,21 @@ if grep -Fq 'simctl shutdown SIM-27' "$temporary_root/boot-race-other-owner-boot
   echo 'The action shut down a simulator another process was still booting.' >&2
   exit 1
 fi
+grep -Fxq 'simctl bootstatus SIM-27' "$temporary_root/boot-race-other-owner-booting/calls"
+
+run_case boot-race-state-unreadable \
+  STUB_BOOT_FAILS=true \
+  STUB_BOOT_RACE_OTHER_OWNER=true \
+  STUB_RACE_DEVICE_MISSING=true
+grep -Fxq 'simctl bootstatus SIM-27' "$temporary_root/boot-race-state-unreadable/calls"
+if grep -Fq 'simctl shutdown SIM-27' "$temporary_root/boot-race-state-unreadable/calls"; then
+  echo 'The action claimed ownership after the simulator state became unreadable.' >&2
+  exit 1
+fi
+
+run_case three-component-sdk STUB_SDK_NAME=iphonesimulator27.0.1
+grep -Fxq 'classification=launch-passed' "$temporary_root/three-component-sdk/output"
+grep -Fxq 'app-sdk-major=27' "$temporary_root/three-component-sdk/output"
 
 if run_case excessive-survival SURVIVAL_SECONDS=121; then
   echo 'Expected an excessive survival window to fail.' >&2

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -110,6 +110,7 @@ if [[ -n "${STUB_PS_EXIT_STATUS:-}" ]]; then
   echo 'stubbed ps inspection error' >&2
   exit "$STUB_PS_EXIT_STATUS"
 fi
+[[ "${STUB_PS_SUCCESS_DIAGNOSTIC:-false}" != true ]] || echo 'stubbed successful ps diagnostic' >&2
 printf '%s %s\n' \
   "${STUB_PROCESS_STATE:-S}" \
   "${STUB_PROCESS_COMMAND:-/Users/runner/Library/Developer/CoreSimulator/Devices/${STUB_DEVICE_UDID:-SIM-27}/data/Containers/Bundle/Application/11111111-1111-1111-1111-111111111111/LaunchSmoke.app/LaunchSmoke}"
@@ -212,6 +213,13 @@ if run_case process-inspection-status-one-with-error STUB_PS_EXIT_STATUS=1; then
 fi
 grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/process-inspection-status-one-with-error/output"
 grep -Fq 'stubbed ps inspection error' "$temporary_root/process-inspection-status-one-with-error/launch.log"
+
+if run_case process-inspection-success-with-diagnostic STUB_PS_SUCCESS_DIAGNOSTIC=true; then
+  echo 'Expected ps status 0 with diagnostic output to be an infrastructure failure.' >&2
+  exit 1
+fi
+grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/process-inspection-success-with-diagnostic/output"
+grep -Fq 'stubbed successful ps diagnostic' "$temporary_root/process-inspection-success-with-diagnostic/launch.log"
 
 if run_case launch-rejected STUB_LAUNCH_FAILS=true; then
   echo 'Expected a rejected simctl launch to fail.' >&2
@@ -527,15 +535,10 @@ if run_case invalid-log-path LAUNCH_LOG_PATH=$'/tmp/launch.log\ninjected=value';
   exit 1
 fi
 grep -Fq 'LAUNCH_LOG_PATH must be a single-line path' "$temporary_root/invalid-log-path/command.log"
-if [[ -e "$temporary_root/invalid-log-path/output" ]]; then
-  grep -Fxq 'classification=launch-failed' "$temporary_root/invalid-log-path/output"
-  grep -Fxq 'bundle-id=unknown' "$temporary_root/invalid-log-path/output"
-  grep -Fxq 'launched-pid=unknown' "$temporary_root/invalid-log-path/output"
-  grep -Fxq 'simulator-udid=unknown' "$temporary_root/invalid-log-path/output"
-else
-  echo 'A rejected log path did not publish its failure classification.' >&2
-  exit 1
-fi
+grep -Fxq 'classification=launch-failed' "$temporary_root/invalid-log-path/output"
+grep -Fxq 'bundle-id=unknown' "$temporary_root/invalid-log-path/output"
+grep -Fxq 'launched-pid=unknown' "$temporary_root/invalid-log-path/output"
+grep -Fxq 'simulator-udid=unknown' "$temporary_root/invalid-log-path/output"
 
 unwritable_parent="$temporary_root/unwritable-parent"
 touch "$unwritable_parent"
@@ -547,6 +550,23 @@ grep -Fq 'LAUNCH_LOG_PATH could not be created' "$temporary_root/unwritable-log-
 grep -Fxq 'classification=launch-failed' "$temporary_root/unwritable-log-path/output"
 grep -Fxq 'bundle-id=unknown' "$temporary_root/unwritable-log-path/output"
 grep -Fxq 'launched-pid=unknown' "$temporary_root/unwritable-log-path/output"
+
+default_unwritable_parent="$temporary_root/default-unwritable-parent"
+touch "$default_unwritable_parent"
+if env \
+  APP_PATH="$app_path" \
+  EXPECTED_IOS_MAJOR=27 \
+  SURVIVAL_SECONDS=1 \
+  LAUNCH_LOG_PATH= \
+  RUNNER_TEMP="$default_unwritable_parent" \
+  GITHUB_OUTPUT="$temporary_root/default-unwritable-output" \
+  GITHUB_STEP_SUMMARY="$temporary_root/default-unwritable-summary" \
+  "$BASH" "$script_dir/launch.sh" > "$temporary_root/default-unwritable-command.log" 2>&1; then
+  echo 'Expected an uncreatable default log path to fail.' >&2
+  exit 1
+fi
+grep -Fq 'The default launch log path could not be created' "$temporary_root/default-unwritable-command.log"
+grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/default-unwritable-output"
 
 default_log_root="$temporary_root/default-log-path"
 mkdir -p "$default_log_root"

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -232,12 +232,8 @@ fi
 grep -Fq 'ps observation after 1s: T ' "$temporary_root/stopped-process/launch.log"
 grep -Fq 'exited, became non-runnable, or changed identity' "$temporary_root/stopped-process/launch.log"
 
-if run_case uninterruptible-process STUB_PROCESS_STATE=U; then
-  echo 'Expected an uninterruptible process to fail the survival check.' >&2
-  exit 1
-fi
-grep -Fq 'ps observation after 1s: U ' "$temporary_root/uninterruptible-process/launch.log"
-grep -Fq 'exited, became non-runnable, or changed identity' "$temporary_root/uninterruptible-process/launch.log"
+run_case uninterruptible-process STUB_PROCESS_STATE=U
+grep -Fxq 'classification=launch-passed' "$temporary_root/uninterruptible-process/output"
 
 if run_case invalid-bundle-id STUB_BUNDLE_ID=$'io.customer.test\ninjected=value'; then
   echo 'Expected an invalid bundle identifier to fail.' >&2

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -12,6 +12,14 @@ report_test_failure() {
 trap 'report_test_failure "$LINENO"' ERR
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for production_tool in \
+  'XCRUN_BIN: xcrun' \
+  'PYTHON_BIN: python3' \
+  'PLIST_BUDDY_BIN: /usr/libexec/PlistBuddy' \
+  'PS_BIN: ps' \
+  'SLEEP_BIN: sleep'; do
+  grep -Fq "$production_tool" "$script_dir/action.yml"
+done
 temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/launch-ios-simulator-app.XXXXXX")"
 trap 'rm -rf "$temporary_root"' EXIT
 
@@ -106,6 +114,14 @@ cat > "$stub_bin/ps" <<'STUB'
 #!/usr/bin/env bash
 printf 'ps %s\n' "$*" >> "$STUB_CALLS"
 [[ "${STUB_PROCESS_ALIVE:-true}" == true ]] || exit 1
+if [[ -n "${STUB_PS_ALIVE_POLLS:-}" ]]; then
+  count_file="$STUB_CALLS.ps-count"
+  count=0
+  [[ ! -f "$count_file" ]] || count="$(<"$count_file")"
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$count_file"
+  (( count <= STUB_PS_ALIVE_POLLS )) || exit 1
+fi
 if [[ -n "${STUB_PS_EXIT_STATUS:-}" ]]; then
   echo 'stubbed ps inspection error' >&2
   exit "$STUB_PS_EXIT_STATUS"
@@ -190,6 +206,14 @@ grep -Fxq 'simctl terminate SIM-27 io.customer.test.launch-smoke' "$temporary_ro
 grep -Fxq 'simctl uninstall SIM-27 io.customer.test.launch-smoke' "$temporary_root/process-exited/calls"
 grep -Fxq 'simctl shutdown SIM-27' "$temporary_root/process-exited/calls"
 
+if run_case process-exited-mid-window STUB_PS_ALIVE_POLLS=2; then
+  echo 'Expected an app that exits after two healthy polls to fail.' >&2
+  exit 1
+fi
+grep -Fq 'exited, became non-runnable, or changed identity after 3s of the 5s survival window' \
+  "$temporary_root/process-exited-mid-window/launch.log"
+grep -Fxq 'failure-reason=did-not-survive' "$temporary_root/process-exited-mid-window/output"
+
 if run_case process-exited-delayed-log \
   STUB_PROCESS_ALIVE=false \
   STUB_EMPTY_APP_LOG_ATTEMPTS=2; then
@@ -198,6 +222,15 @@ if run_case process-exited-delayed-log \
 fi
 test "$(grep -Fxc "simctl spawn SIM-27 log show --last 65s --style compact --predicate process == 'LaunchSmoke'" "$temporary_root/process-exited-delayed-log/calls")" -eq 3
 grep -Fq 'stubbed simulator failure log' "$temporary_root/process-exited-delayed-log/launch.log"
+
+if run_case process-exited-log-exhausted \
+  STUB_PROCESS_ALIVE=false \
+  STUB_EMPTY_APP_LOG_ATTEMPTS=5; then
+  echo 'Expected an exited process with unavailable app logs to fail.' >&2
+  exit 1
+fi
+grep -Fq '===== App log for LaunchSmoke =====' "$temporary_root/process-exited-log-exhausted/launch.log"
+test "$(grep -Fxc "simctl spawn SIM-27 log show --last 65s --style compact --predicate process == 'LaunchSmoke'" "$temporary_root/process-exited-log-exhausted/calls")" -eq 5
 
 if run_case process-inspection-failed STUB_PS_EXIT_STATUS=2; then
   echo 'Expected a process-inspection failure to fail.' >&2
@@ -411,12 +444,15 @@ run_case executable-with-space \
   STUB_PROCESS_COMMAND='/Users/runner/Library/Developer/CoreSimulator/Devices/SIM-27/data/Launch Smoke.app/Launch Smoke'
 grep -Fxq 'classification=launch-passed' "$temporary_root/executable-with-space/output"
 
-for invalid_executable in ' LaunchSmoke' 'LaunchSmoke '; do
-  if run_case invalid-executable-whitespace STUB_EXECUTABLE="$invalid_executable"; then
-    echo 'Expected executable whitespace at the boundary to fail.' >&2
+for whitespace_case in leading trailing; do
+  invalid_executable=' LaunchSmoke'
+  [[ "$whitespace_case" != trailing ]] || invalid_executable='LaunchSmoke '
+  case_name="invalid-executable-$whitespace_case-space"
+  if run_case "$case_name" STUB_EXECUTABLE="$invalid_executable"; then
+    echo "Expected executable $whitespace_case whitespace to fail." >&2
     exit 1
   fi
-  grep -Fxq 'failure-reason=invalid-app' "$temporary_root/invalid-executable-whitespace/output"
+  grep -Fxq 'failure-reason=invalid-app' "$temporary_root/$case_name/output"
 done
 
 if run_case bootstatus-rejected STUB_BOOTSTATUS_FAILS=true; then
@@ -447,6 +483,13 @@ fi
 grep -Fq 'APP_PATH is required' "$temporary_root/missing-app-input/launch.log"
 grep -Fxq 'classification=launch-failed' "$temporary_root/missing-app-input/output"
 grep -Fxq 'failure-reason=invalid-input' "$temporary_root/missing-app-input/output"
+
+if run_case option-shaped-app-path APP_PATH=-fixture; then
+  echo 'Expected an option-shaped app path to fail.' >&2
+  exit 1
+fi
+grep -Fq 'APP_PATH must not be option-shaped' "$temporary_root/option-shaped-app-path/launch.log"
+grep -Fxq 'failure-reason=invalid-input' "$temporary_root/option-shaped-app-path/output"
 
 if run_case invalid-survival SURVIVAL_SECONDS=0; then
   echo 'Expected an invalid survival window to fail.' >&2

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -330,6 +330,14 @@ run_case executable-with-space \
   STUB_PROCESS_COMMAND='/Users/runner/Library/Developer/CoreSimulator/Devices/SIM-27/data/Launch Smoke.app/Launch Smoke'
 grep -Fxq 'classification=launch-passed' "$temporary_root/executable-with-space/output"
 
+for invalid_executable in ' LaunchSmoke' 'LaunchSmoke '; do
+  if run_case invalid-executable-whitespace STUB_EXECUTABLE="$invalid_executable"; then
+    echo 'Expected executable whitespace at the boundary to fail.' >&2
+    exit 1
+  fi
+  grep -Fxq 'failure-reason=invalid-app' "$temporary_root/invalid-executable-whitespace/output"
+done
+
 if run_case bootstatus-rejected STUB_BOOTSTATUS_FAILS=true; then
   echo 'Expected bootstatus failure to fail.' >&2
   exit 1

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -43,12 +43,16 @@ printf '%s\n' "$*" >> "$STUB_CALLS"
     printf '%s\n' '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Shutdown","isAvailable":true,"name":"iPhone 17 Pro","udid":"INVALID UDID"}]}}'
   elif [[ "${STUB_BOOT_RACE_OTHER_OWNER:-false}" == true ]] \
     && [[ "$(grep -Fc 'simctl list devices available --json' "$STUB_CALLS")" -gt 1 ]]; then
-    printf '%s\n' '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Booted","isAvailable":true,"name":"iPhone 17 Pro","udid":"SIM-27"}]}}'
+    printf '%s\n' "{\"devices\":{\"com.apple.CoreSimulator.SimRuntime.iOS-27-0\":[{\"state\":\"${STUB_RACE_STATE:-Booted}\",\"isAvailable\":true,\"name\":\"iPhone 17 Pro\",\"udid\":\"SIM-27\"}]}}"
   elif [[ "${STUB_NO_DEVICES:-false}" == true ]]; then
     printf '%s\n' '{"devices":{}}'
   elif [[ "${STUB_DEVICE_BOOTED:-false}" == true ]]; then
     cat <<'JSON'
 {"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Booted","isAvailable":true,"name":"iPhone 17 Pro","udid":"SIM-27"}]}}
+JSON
+  elif [[ "${STUB_PREFER_BOOTED_DEVICE:-false}" == true ]]; then
+    cat <<'JSON'
+{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-27-1":[{"state":"Shutdown","isAvailable":true,"name":"iPhone Newer","udid":"SIM-27-1"}],"com.apple.CoreSimulator.SimRuntime.iOS-27-0":[{"state":"Booted","isAvailable":true,"name":"iPhone Booted","udid":"SIM-27"}]}}
 JSON
   elif [[ "${STUB_TRANSITIONAL_DEVICE:-false}" == true ]]; then
     cat <<'JSON'
@@ -87,6 +91,7 @@ cat > "$stub_bin/ps" <<'STUB'
 #!/usr/bin/env bash
 printf 'ps %s\n' "$*" >> "$STUB_CALLS"
 [[ "${STUB_PROCESS_ALIVE:-true}" == true ]] || exit 1
+[[ -z "${STUB_PS_EXIT_STATUS:-}" ]] || exit "$STUB_PS_EXIT_STATUS"
 printf '%s %s\n' \
   "${STUB_PROCESS_STATE:-S}" \
   "${STUB_PROCESS_COMMAND:-/Users/runner/Library/Developer/CoreSimulator/Devices/${STUB_DEVICE_UDID:-SIM-27}/data/Containers/Bundle/Application/11111111-1111-1111-1111-111111111111/LaunchSmoke.app/LaunchSmoke}"
@@ -157,6 +162,15 @@ grep -Fq 'exited or changed identity after 1s of the 5s survival window' "$tempo
 grep -Fxq 'failure-reason=did-not-survive' "$temporary_root/process-exited/output"
 grep -Fxq 'launched-pid=4242' "$temporary_root/process-exited/output"
 grep -Fq 'stubbed simulator failure log' "$temporary_root/process-exited/launch.log"
+grep -Fxq 'simctl terminate SIM-27 io.customer.test.launch-smoke' "$temporary_root/process-exited/calls"
+grep -Fxq 'simctl uninstall SIM-27 io.customer.test.launch-smoke' "$temporary_root/process-exited/calls"
+grep -Fxq 'simctl shutdown SIM-27' "$temporary_root/process-exited/calls"
+
+if run_case process-inspection-failed STUB_PS_EXIT_STATUS=2; then
+  echo 'Expected a process-inspection failure to fail.' >&2
+  exit 1
+fi
+grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/process-inspection-failed/output"
 
 if run_case launch-rejected STUB_LAUNCH_FAILS=true; then
   echo 'Expected a rejected simctl launch to fail.' >&2
@@ -283,6 +297,13 @@ if grep -Fq 'simctl boot SIM-27' "$temporary_root/already-booted/calls" \
   exit 1
 fi
 
+run_case prefer-booted-device STUB_PREFER_BOOTED_DEVICE=true
+grep -Fxq 'simulator-udid=SIM-27' "$temporary_root/prefer-booted-device/output"
+if grep -Fq 'SIM-27-1' "$temporary_root/prefer-booted-device/calls"; then
+  echo 'The action preferred a newer shutdown runtime over a matching booted runtime.' >&2
+  exit 1
+fi
+
 run_case transitional-device STUB_TRANSITIONAL_DEVICE=true
 grep -Fxq 'simulator-udid=SIM-27' "$temporary_root/transitional-device/output"
 if grep -Fq 'ZZZ-TRANSITIONAL' "$temporary_root/transitional-device/calls"; then
@@ -354,6 +375,15 @@ if grep -Fq 'simctl shutdown SIM-27' "$temporary_root/boot-race-other-owner/call
   exit 1
 fi
 
+run_case boot-race-other-owner-booting \
+  STUB_BOOT_FAILS=true \
+  STUB_BOOT_RACE_OTHER_OWNER=true \
+  STUB_RACE_STATE=Booting
+if grep -Fq 'simctl shutdown SIM-27' "$temporary_root/boot-race-other-owner-booting/calls"; then
+  echo 'The action shut down a simulator another process was still booting.' >&2
+  exit 1
+fi
+
 if run_case excessive-survival SURVIVAL_SECONDS=121; then
   echo 'Expected an excessive survival window to fail.' >&2
   exit 1
@@ -373,6 +403,9 @@ fi
 grep -Fq 'LAUNCH_LOG_PATH must be a single-line path' "$temporary_root/invalid-log-path/command.log"
 if [[ -e "$temporary_root/invalid-log-path/output" ]]; then
   grep -Fxq 'classification=launch-failed' "$temporary_root/invalid-log-path/output"
+  grep -Fxq 'bundle-id=unknown' "$temporary_root/invalid-log-path/output"
+  grep -Fxq 'launched-pid=unknown' "$temporary_root/invalid-log-path/output"
+  grep -Fxq 'simulator-udid=unknown' "$temporary_root/invalid-log-path/output"
 else
   echo 'A rejected log path did not publish its failure classification.' >&2
   exit 1
@@ -386,5 +419,29 @@ if run_case unwritable-log-path LAUNCH_LOG_PATH="$unwritable_parent/launch.log";
 fi
 grep -Fq 'LAUNCH_LOG_PATH could not be created' "$temporary_root/unwritable-log-path/command.log"
 grep -Fxq 'classification=launch-failed' "$temporary_root/unwritable-log-path/output"
+grep -Fxq 'bundle-id=unknown' "$temporary_root/unwritable-log-path/output"
+grep -Fxq 'launched-pid=unknown' "$temporary_root/unwritable-log-path/output"
+
+default_log_root="$temporary_root/default-log-path"
+mkdir -p "$default_log_root"
+current_case=default-log-path
+: > "$default_log_root/calls"
+env \
+  APP_PATH="$app_path" \
+  EXPECTED_IOS_MAJOR=27 \
+  SURVIVAL_SECONDS=1 \
+  RUNNER_TEMP="$default_log_root" \
+  GITHUB_OUTPUT="$default_log_root/output" \
+  XCRUN_BIN="$stub_bin/xcrun" \
+  PYTHON_BIN=python3 \
+  PLIST_BUDDY_BIN="$stub_bin/plist-buddy" \
+  PS_BIN="$stub_bin/ps" \
+  SLEEP_BIN="$stub_bin/sleep" \
+  STUB_CALLS="$default_log_root/calls" \
+  STUB_DEVICE_UDID=SIM-27 \
+  "$BASH" "$script_dir/launch.sh" > "$default_log_root/command.log" 2>&1
+default_log_path="$(sed -n 's/^log-path=//p' "$default_log_root/output")"
+[[ "$default_log_path" == "$default_log_root"/ios-simulator-launch-*.log ]]
+test -s "$default_log_path"
 
 echo 'launch-simulator-app tests passed'

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -110,10 +110,12 @@ if [[ -n "${STUB_PS_EXIT_STATUS:-}" ]]; then
   echo 'stubbed ps inspection error' >&2
   exit "$STUB_PS_EXIT_STATUS"
 fi
+[[ "${STUB_PS_EMPTY_SUCCESS:-false}" != true ]] || exit 0
 [[ "${STUB_PS_SUCCESS_DIAGNOSTIC:-false}" != true ]] || echo 'stubbed successful ps diagnostic' >&2
 printf '%s %s\n' \
   "${STUB_PROCESS_STATE:-S}" \
   "${STUB_PROCESS_COMMAND:-/Users/runner/Library/Developer/CoreSimulator/Devices/${STUB_DEVICE_UDID:-SIM-27}/data/Containers/Bundle/Application/11111111-1111-1111-1111-111111111111/LaunchSmoke.app/LaunchSmoke}"
+[[ "${STUB_PS_TRAILING_DIAGNOSTIC:-false}" != true ]] || echo 'stubbed trailing ps diagnostic' >&2
 STUB
 
 cat > "$stub_bin/sleep" <<'STUB'
@@ -220,6 +222,16 @@ if run_case process-inspection-success-with-diagnostic STUB_PS_SUCCESS_DIAGNOSTI
 fi
 grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/process-inspection-success-with-diagnostic/output"
 grep -Fq 'stubbed successful ps diagnostic' "$temporary_root/process-inspection-success-with-diagnostic/launch.log"
+
+for ps_case in process-inspection-empty-success process-inspection-trailing-diagnostic; do
+  ps_env=STUB_PS_EMPTY_SUCCESS=true
+  [[ "$ps_case" != process-inspection-trailing-diagnostic ]] || ps_env=STUB_PS_TRAILING_DIAGNOSTIC=true
+  if run_case "$ps_case" "$ps_env"; then
+    echo "Expected $ps_case to be an infrastructure failure." >&2
+    exit 1
+  fi
+  grep -Fxq 'failure-reason=unexpected-error' "$temporary_root/$ps_case/output"
+done
 
 if run_case launch-rejected STUB_LAUNCH_FAILS=true; then
   echo 'Expected a rejected simctl launch to fail.' >&2
@@ -539,6 +551,7 @@ grep -Fxq 'classification=launch-failed' "$temporary_root/invalid-log-path/outpu
 grep -Fxq 'bundle-id=unknown' "$temporary_root/invalid-log-path/output"
 grep -Fxq 'launched-pid=unknown' "$temporary_root/invalid-log-path/output"
 grep -Fxq 'simulator-udid=unknown' "$temporary_root/invalid-log-path/output"
+grep -Fxq 'failure-reason=invalid-input' "$temporary_root/invalid-log-path/output"
 
 unwritable_parent="$temporary_root/unwritable-parent"
 touch "$unwritable_parent"
@@ -550,9 +563,11 @@ grep -Fq 'LAUNCH_LOG_PATH could not be created' "$temporary_root/unwritable-log-
 grep -Fxq 'classification=launch-failed' "$temporary_root/unwritable-log-path/output"
 grep -Fxq 'bundle-id=unknown' "$temporary_root/unwritable-log-path/output"
 grep -Fxq 'launched-pid=unknown' "$temporary_root/unwritable-log-path/output"
+grep -Fxq 'failure-reason=invalid-input' "$temporary_root/unwritable-log-path/output"
 
 default_unwritable_parent="$temporary_root/default-unwritable-parent"
 touch "$default_unwritable_parent"
+current_case=default-unwritable-log-path
 if env \
   APP_PATH="$app_path" \
   EXPECTED_IOS_MAJOR=27 \

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -155,6 +155,7 @@ if run_case process-exited STUB_PROCESS_ALIVE=false; then
 fi
 grep -Fq 'exited or changed identity after 1s of the 5s survival window' "$temporary_root/process-exited/launch.log"
 grep -Fxq 'failure-reason=did-not-survive' "$temporary_root/process-exited/output"
+grep -Fxq 'launched-pid=4242' "$temporary_root/process-exited/output"
 grep -Fq 'stubbed simulator failure log' "$temporary_root/process-exited/launch.log"
 
 if run_case launch-rejected STUB_LAUNCH_FAILS=true; then
@@ -313,6 +314,7 @@ if run_case missing-app APP_PATH="$temporary_root/Missing.app"; then
   exit 1
 fi
 grep -Fq 'Built simulator app is missing or has no Info.plist' "$temporary_root/missing-app/launch.log"
+grep -Fxq 'launched-pid=unknown' "$temporary_root/missing-app/output"
 
 if run_case missing-app-input APP_PATH=; then
   echo 'Expected an empty app path to fail through the action contract.' >&2

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -409,6 +409,13 @@ if grep -Fq 'simctl shutdown SIM-27' "$temporary_root/boot-race-other-owner-boot
 fi
 grep -Fxq 'simctl bootstatus SIM-27' "$temporary_root/boot-race-other-owner-booting/calls"
 
+run_case boot-race-reread-shutdown \
+  STUB_BOOT_FAILS=true \
+  STUB_BOOT_RACE_OTHER_OWNER=true \
+  STUB_RACE_STATE=Shutdown
+grep -Fxq 'simctl bootstatus SIM-27 -b' "$temporary_root/boot-race-reread-shutdown/calls"
+grep -Fxq 'simctl shutdown SIM-27' "$temporary_root/boot-race-reread-shutdown/calls"
+
 if run_case boot-race-state-unreadable \
   STUB_BOOT_FAILS=true \
   STUB_BOOT_RACE_OTHER_OWNER=true \

--- a/github-actions/ios/launch-simulator-app/v1/test.sh
+++ b/github-actions/ios/launch-simulator-app/v1/test.sh
@@ -163,6 +163,7 @@ if run_case process-exited STUB_PROCESS_ALIVE=false; then
   exit 1
 fi
 grep -Fq 'exited or changed identity after 1s of the 5s survival window' "$temporary_root/process-exited/launch.log"
+grep -Fq 'ps observation after 1s:' "$temporary_root/process-exited/launch.log"
 grep -Fxq 'failure-reason=did-not-survive' "$temporary_root/process-exited/output"
 grep -Fxq 'launched-pid=4242' "$temporary_root/process-exited/output"
 grep -Fq 'stubbed simulator failure log' "$temporary_root/process-exited/launch.log"
@@ -408,11 +409,18 @@ if grep -Fq 'simctl shutdown SIM-27' "$temporary_root/boot-race-other-owner-boot
 fi
 grep -Fxq 'simctl bootstatus SIM-27' "$temporary_root/boot-race-other-owner-booting/calls"
 
-run_case boot-race-state-unreadable \
+if run_case boot-race-state-unreadable \
   STUB_BOOT_FAILS=true \
   STUB_BOOT_RACE_OTHER_OWNER=true \
-  STUB_RACE_DEVICE_MISSING=true
-grep -Fxq 'simctl bootstatus SIM-27' "$temporary_root/boot-race-state-unreadable/calls"
+  STUB_RACE_DEVICE_MISSING=true; then
+  echo 'Expected an unreadable simulator state after boot rejection to fail.' >&2
+  exit 1
+fi
+grep -Fxq 'failure-reason=simulator-boot-failed' "$temporary_root/boot-race-state-unreadable/output"
+if grep -Fq 'simctl bootstatus SIM-27' "$temporary_root/boot-race-state-unreadable/calls"; then
+  echo 'The action waited for a simulator whose ownership and state were unknown.' >&2
+  exit 1
+fi
 if grep -Fq 'simctl shutdown SIM-27' "$temporary_root/boot-race-state-unreadable/calls"; then
   echo 'The action claimed ownership after the simulator state became unreadable.' >&2
   exit 1


### PR DESCRIPTION
## Summary

Adds a reusable iOS simulator launch smoke action for the Xcode 27 nightly workflows. It selects the requested runtime, verifies the app was built with the matching simulator SDK, installs and launches the app, and proves the expected executable remains alive for the configured window.

This closes the blind spot where a sample app compiles successfully but terminates immediately at launch.

## Validation

- Bash unit tests cover healthy launch, early process exit, rejected and malformed simctl launch, long simulator process paths, and invalid inputs.
- bash -n, ShellCheck, actionlint, and git diff --check pass.
- Two Claude Code Opus adversarial passes found and drove fixes for lost simctl diagnostics, wrong-runtime false passes, BSD ps path truncation, PID reuse, and incomplete pre-launch failure reporting.
- Hosted Xcode 27 native APN/FCM and Flutter SwiftPM/CocoaPods workflows used this action successfully. Flutter proved both the compile-success/launch-failure negative control and the UIScene positive launch.

## Boundary

This verifies simulator install, launch, executable identity, and process survival. It does not prove lifecycle callbacks, push delivery, signing, physical-device behavior, or App Store submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to new CI tooling and documentation in this repo; simulator lifecycle is scoped to test fixtures with cleanup, though shared-runner simulator races remain a documented operational caveat.
> 
> **Overview**
> Adds **`github-actions/ios/launch-simulator-app/v1`**, a composite action that installs a simulator `.app`, picks an iPhone runtime matching **`expected-ios-major`**, checks **`DTSDKName`** against that major, launches via `simctl`, and fails if the process does not stay alive for **`survival-seconds`**. It exposes structured outputs (`classification`, `failure-reason`, simulator metadata) and writes bounded failure diagnostics to an explicit **`log-path`** (without echoing app logs as GitHub workflow commands), then terminates and uninstalls the app.
> 
> **`launch.sh`** is backed by a large stub-based **`test.sh`** suite (success, early exit, boot races, SDK mismatch, forged-output hardening, etc.). **README** documents consumer contracts (log upload with `continue-on-error`, job timeouts, simulator isolation).
> 
> **`.github/workflows/ios-actions-test.yml`** now runs `bash -n` / ShellCheck on all `github-actions/ios/*/v1/*.sh`, runs the new unit tests on Ubuntu and macOS Bash 3.2, and on macOS builds minimal UIScene Swift fixtures (healthy + delayed-crash) to smoke-test the composite action end-to-end, including crash rejection and diagnostic log content, with failure artifact upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d9bddf84e03d62d35bf0850e52d928749945d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

